### PR TITLE
Updated Datasources tests

### DIFF
--- a/src/main/java/org/jboss/hal/testsuite/fragment/shared/modal/WizardWindow.java
+++ b/src/main/java/org/jboss/hal/testsuite/fragment/shared/modal/WizardWindow.java
@@ -1,5 +1,6 @@
 package org.jboss.hal.testsuite.fragment.shared.modal;
 
+import org.jboss.hal.testsuite.util.Console;
 import org.junit.Assert;
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.hal.testsuite.fragment.WindowFragment;
@@ -23,8 +24,7 @@ public class WizardWindow extends WindowFragment {
         String label = PropUtils.get("modals.wizard.next.label");
         clickButton(label);
 
-        // TODO: possible refactoring to dynamic wait
-        Graphene.waitModel().withTimeout(2, TimeUnit.SECONDS);
+        Console.withBrowser(browser).waitUntilFinished();
     }
 
     /**

--- a/src/main/java/org/jboss/hal/testsuite/page/config/ConfigurationPage.java
+++ b/src/main/java/org/jboss/hal/testsuite/page/config/ConfigurationPage.java
@@ -2,6 +2,8 @@ package org.jboss.hal.testsuite.page.config;
 
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.graphene.findby.ByJQuery;
+import org.jboss.arquillian.graphene.wait.AttributeBuilder;
+import org.jboss.arquillian.graphene.wait.ElementBuilder;
 import org.jboss.hal.testsuite.cli.Library;
 import org.jboss.hal.testsuite.fragment.ConfigAreaFragment;
 import org.jboss.hal.testsuite.fragment.shared.modal.ConfirmationWindow;
@@ -21,7 +23,7 @@ public class ConfigurationPage extends ConfigPage {
     public ConfigurationPage select(String label) {
         String cellClass = PropUtils.get("table.cell.class");
         String cellSelectedClass = PropUtils.get("table.cell.selected.class");
-        By selector = ByJQuery.selector("." + cellClass + ":contains('" + label + "')");
+        By selector = By.ByXPath.xpath("//td[contains(@class,'" + cellClass + "') and descendant::div[@class='navigation-column-item' and text()='" + label + "']]");
         getContentRoot().findElement(selector).click();
         Graphene.waitModel().until().element(selector).attribute("class").contains(cellSelectedClass);
         Library.letsSleep(1000);

--- a/src/main/java/org/jboss/hal/testsuite/page/config/ConfigurationPage.java
+++ b/src/main/java/org/jboss/hal/testsuite/page/config/ConfigurationPage.java
@@ -2,8 +2,6 @@ package org.jboss.hal.testsuite.page.config;
 
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.graphene.findby.ByJQuery;
-import org.jboss.arquillian.graphene.wait.AttributeBuilder;
-import org.jboss.arquillian.graphene.wait.ElementBuilder;
 import org.jboss.hal.testsuite.cli.Library;
 import org.jboss.hal.testsuite.fragment.ConfigAreaFragment;
 import org.jboss.hal.testsuite.fragment.shared.modal.ConfirmationWindow;

--- a/src/main/java/org/jboss/hal/testsuite/page/config/DatasourcesPage.java
+++ b/src/main/java/org/jboss/hal/testsuite/page/config/DatasourcesPage.java
@@ -3,14 +3,14 @@ package org.jboss.hal.testsuite.page.config;
 import org.jboss.arquillian.graphene.page.Location;
 import org.jboss.hal.testsuite.fragment.config.datasource.DatasourceConfigArea;
 import org.jboss.hal.testsuite.fragment.config.datasource.DatasourceWizard;
-import org.jboss.hal.testsuite.page.ConfigPage;
+import org.jboss.hal.testsuite.util.Console;
 
 /**
  * Created by jcechace on 22/02/14.
  */
 
-@Location("#datasources")
-public class DatasourcesPage extends ConfigPage {
+@Location("#profiles/ds-finder")
+public class DatasourcesPage extends ConfigurationPage {
     @Override
     public DatasourceConfigArea getConfig() {
         return getConfig(DatasourceConfigArea.class);
@@ -21,7 +21,8 @@ public class DatasourcesPage extends ConfigPage {
     }
 
     public void switchToXA() {
-        switchTab("XA Datasources");
+        select("XA");
+        Console.withBrowser(browser).waitUntilLoaded();
     }
 
 }

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/AbstractTestConnectionTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/AbstractTestConnectionTestCase.java
@@ -9,6 +9,7 @@ import org.jboss.hal.testsuite.fragment.config.datasource.TestConnectionWindow;
 import org.jboss.hal.testsuite.fragment.formeditor.Editor;
 import org.jboss.hal.testsuite.fragment.formeditor.PropertyEditor;
 import org.jboss.hal.testsuite.page.config.DatasourcesPage;
+import org.jboss.hal.testsuite.util.Console;
 import org.junit.Assert;
 import org.openqa.selenium.WebDriver;
 
@@ -24,7 +25,8 @@ public abstract class AbstractTestConnectionTestCase {
     protected DatasourcesPage datasourcesPage;
 
     protected void testConnection(String name, boolean expected) {
-        datasourcesPage.getResourceManager().selectByName(name);
+        datasourcesPage.view(name);
+        Console.withBrowser(browser).waitUntilLoaded();
 
         DatasourceConfigArea config = datasourcesPage.getConfig();
         ConnectionConfig connection = config.connectionConfig();

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/DataSourcesOperations.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/DataSourcesOperations.java
@@ -3,7 +3,6 @@ package org.jboss.hal.testsuite.test.configuration.datasources;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jboss.hal.testsuite.cli.CliClient;
 import org.jboss.hal.testsuite.cli.CliConstants;
-import org.jboss.hal.testsuite.cli.CliUtils;
 import org.jboss.hal.testsuite.util.ConfigUtils;
 
 /**
@@ -58,10 +57,9 @@ public class DataSourcesOperations {
                 " --name=" + name +
                 " --jndi-name=java:/xa-datasources/" + name +
                 " --driver-name=h2" +
-                " --enabled=true";
-        String command2 = CliUtils.buildCommand(getXADsAddress(name) + "/xa-datasource-properties=URL", ":add(value=\"" + url + "\")");
+                " --enabled=true" +
+                " --xa-datasource-properties=URL=\"" + url + "\"";
         client.executeCommand(command);
-        client.executeCommand(command2);
         return name;
     }
 

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/DomainTestConnectionTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/DomainTestConnectionTestCase.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 public class DomainTestConnectionTestCase extends AbstractTestConnectionTestCase {
 
     @Page
-    DomainConfigurationPage domainConfigurationPage;
+    private DomainConfigurationPage domainConfigurationPage;
 
     private static String dsNameValid;
     private static String dsSameNameValid;
@@ -66,7 +66,7 @@ public class DomainTestConnectionTestCase extends AbstractTestConnectionTestCase
         Console.withBrowser(browser).waitUntilLoaded();
         Graphene.goTo(DomainConfigurationPage.class);
         Console.withBrowser(browser).waitUntilLoaded();
-        domainConfigurationPage.selectProfile(ConfigUtils.getDefaultProfile()).view("Datasources");
+        domainConfigurationPage.selectProfile(ConfigUtils.getDefaultProfile()).select("Datasources").select("Non-XA");
         Console.withBrowser(browser).waitUntilLoaded();
     }
 
@@ -91,7 +91,7 @@ public class DomainTestConnectionTestCase extends AbstractTestConnectionTestCase
     public void testValidWithSameNameInOtherGroup() throws IOException {
         Graphene.goTo(DomainConfigurationPage.class);
         Console.withBrowser(browser).waitUntilLoaded();
-        domainConfigurationPage.selectProfile("full-ha").view("Datasources");
+        domainConfigurationPage.selectProfile("full-ha").select("Datasources").select("Non-XA");
         Console.withBrowser(browser).waitUntilFinished();
         manager.startAllServers(10L);
         testConnection(dsSameNameValid, true);

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/DomainTestConnectionTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/DomainTestConnectionTestCase.java
@@ -1,12 +1,13 @@
 package org.jboss.hal.testsuite.test.configuration.datasources;
 
 import org.jboss.arquillian.graphene.Graphene;
+import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.hal.testsuite.cli.CliClient;
 import org.jboss.hal.testsuite.cli.CliClientFactory;
-import org.jboss.hal.testsuite.cli.DomainCliClient;
 import org.jboss.hal.testsuite.cli.DomainManager;
-import org.jboss.hal.testsuite.page.config.DatasourcesPage;
+import org.jboss.hal.testsuite.page.config.DomainConfigurationPage;
+import org.jboss.hal.testsuite.page.home.HomePage;
 import org.jboss.hal.testsuite.test.category.Domain;
 import org.jboss.hal.testsuite.util.ConfigUtils;
 import org.jboss.hal.testsuite.util.Console;
@@ -26,6 +27,9 @@ import java.io.IOException;
 @Category(Domain.class)
 @RunWith(Arquillian.class)
 public class DomainTestConnectionTestCase extends AbstractTestConnectionTestCase {
+
+    @Page
+    DomainConfigurationPage domainConfigurationPage;
 
     private static String dsNameValid;
     private static String dsSameNameValid;
@@ -58,9 +62,12 @@ public class DomainTestConnectionTestCase extends AbstractTestConnectionTestCase
 
     @Before
     public void before() {
-        Graphene.goTo(DatasourcesPage.class);
+        Graphene.goTo(HomePage.class);
         Console.withBrowser(browser).waitUntilLoaded();
-        datasourcesPage.pickProfile(ConfigUtils.getDefaultProfile());
+        Graphene.goTo(DomainConfigurationPage.class);
+        Console.withBrowser(browser).waitUntilLoaded();
+        domainConfigurationPage.selectProfile(ConfigUtils.getDefaultProfile()).view("Datasources");
+        Console.withBrowser(browser).waitUntilLoaded();
     }
 
     @After
@@ -82,9 +89,11 @@ public class DomainTestConnectionTestCase extends AbstractTestConnectionTestCase
 
     @Test
     public void testValidWithSameNameInOtherGroup() throws IOException {
+        Graphene.goTo(DomainConfigurationPage.class);
+        Console.withBrowser(browser).waitUntilLoaded();
+        domainConfigurationPage.selectProfile("full-ha").view("Datasources");
+        Console.withBrowser(browser).waitUntilFinished();
         manager.startAllServers(10L);
-        datasourcesPage.pickProfile("full-ha");
-
         testConnection(dsSameNameValid, true);
     }
 }

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/TestConnectionTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/TestConnectionTestCase.java
@@ -5,17 +5,18 @@ import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.hal.testsuite.cli.CliClient;
 import org.jboss.hal.testsuite.cli.CliClientFactory;
-import org.jboss.hal.testsuite.page.config.DatasourcesPage;
+import org.jboss.hal.testsuite.page.config.*;
+import org.jboss.hal.testsuite.page.home.HomePage;
 import org.jboss.hal.testsuite.test.category.Shared;
 import org.jboss.hal.testsuite.util.Console;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
 
 /**
  * Created by jcechace on 21/02/14.
@@ -34,7 +35,6 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
 
     private static CliClient client;
     private static DataSourcesOperations dsOps;
-
 
     // Setup
 
@@ -59,6 +59,8 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
 
     @Before
     public void before() {
+        Graphene.goTo(HomePage.class);
+        Console.withBrowser(browser).waitUntilLoaded();
         Graphene.goTo(DatasourcesPage.class);
         Console.withBrowser(browser).waitUntilLoaded();
     }
@@ -71,6 +73,7 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
     // Regular DS tests
     @Test
     public void validDatasource() {
+
         testConnection(dsNameValid, true);
     }
 
@@ -79,14 +82,12 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
         testConnection(dsNameInvalid, false);
     }
 
-    @Ignore
     @Test
     public void validInWizard() {
         String name = RandomStringUtils.randomAlphabetic(6);
         testConnectionInWizard(dsOps, name, VALID_URL, true);
     }
 
-    @Ignore("Test connection fails as stated in [HAL-664]")
     @Test
     public void invalidInWizard() {
         String name = RandomStringUtils.randomAlphabetic(6);
@@ -95,21 +96,18 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
 
 
     // XA DS tests
-    @Ignore("Not able to create xa datasource")
     @Test
     public void validXADatasource() {
         datasourcesPage.switchTab("XA Datasources");
         testConnection(xaDsNameValid, true);
     }
 
-    @Ignore("Not able to create xa datasource")
     @Test
     public void invalidXADatasource() {
         datasourcesPage.switchToXA();
         testConnection(xaDsNameInvalid, false);
     }
 
-    @Ignore("Can't get further than on step 3/4 in wizard")
     @Test
     public void validXAInWizard() {
         datasourcesPage.switchToXA();
@@ -118,7 +116,6 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
         testXAConnectionInWizard(dsOps, name, VALID_URL, true);
     }
 
-    @Ignore("Can't get further than on step 3/4 in wizard")
     @Test
     public void invalidXAInWizard() {
         datasourcesPage.switchToXA();

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/TestConnectionTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/TestConnectionTestCase.java
@@ -63,6 +63,8 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
         Console.withBrowser(browser).waitUntilLoaded();
         Graphene.goTo(DatasourcesPage.class);
         Console.withBrowser(browser).waitUntilLoaded();
+        datasourcesPage.select("Non-XA");
+        Console.withBrowser(browser).waitUntilLoaded();
     }
 
     @After
@@ -73,7 +75,6 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
     // Regular DS tests
     @Test
     public void validDatasource() {
-
         testConnection(dsNameValid, true);
     }
 
@@ -98,13 +99,15 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
     // XA DS tests
     @Test
     public void validXADatasource() {
-        datasourcesPage.switchTab("XA Datasources");
+        datasourcesPage.switchToXA();
+
         testConnection(xaDsNameValid, true);
     }
 
     @Test
     public void invalidXADatasource() {
         datasourcesPage.switchToXA();
+
         testConnection(xaDsNameInvalid, false);
     }
 


### PR DESCRIPTION
Updated DomainTestConnectionTestCase to work with current navigation
- DomainConfigurationPage as entry point
- updated to proper navigation to before()
- updated to proper navigation in testValidWithSameNameInOtherGroup()

Updated WizardWindow to use dynamic waiting instead of fixed one (was causing test not to pass in some cases).

Updated DataSourcesOperations to use only one proper command instead of two, because there was an error in CLI when the first one was entered without `--xa-datasource-properties=`

```
[Server:server-three] 09:21:43,208 ERROR [org.jboss.as.controller.management-operation] (ServerService Thread Pool -- 72) WFLYCTL0013: Operation ("add") failed - address: ([
[Server:server-three]     ("subsystem" => "datasources"),
[Server:server-three]     ("xa-data-source" => "bla")
[Server:server-three] ]) - failure description: "WFLYJCA0069: At least one xa-datasource-property is required for an xa-datasource"
```

Updated TestConnectionTestCase to proper navigation in before() and removed `@Ignore`s
