### PR TITLE
Updated JGroup tests

### DIFF
--- a/src/main/java/org/jboss/hal/testsuite/fragment/config/jgroups/ExecutorTabFragment.java
+++ b/src/main/java/org/jboss/hal/testsuite/fragment/config/jgroups/ExecutorTabFragment.java
@@ -1,0 +1,20 @@
+package org.jboss.hal.testsuite.fragment.config.jgroups;
+
+import org.jboss.arquillian.graphene.Graphene;
+import org.jboss.arquillian.graphene.findby.ByJQuery;
+import org.jboss.hal.testsuite.fragment.BaseFragment;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Created by jkasik on 22.7.15.
+ */
+public class ExecutorTabFragment extends BaseFragment {
+
+    public void openExecutors() {
+        By selector = ByJQuery.selector("a");
+        WebElement link = root.findElement(selector);
+        link.click();
+        Graphene.waitGui().until().element(root).attribute("class").not().contains("gwt-DisclosurePanel-closed");
+    }
+}

--- a/src/main/java/org/jboss/hal/testsuite/fragment/config/jgroups/JGroupsConfigArea.java
+++ b/src/main/java/org/jboss/hal/testsuite/fragment/config/jgroups/JGroupsConfigArea.java
@@ -1,0 +1,14 @@
+package org.jboss.hal.testsuite.fragment.config.jgroups;
+
+import org.jboss.hal.testsuite.fragment.ConfigAreaFragment;
+import org.jboss.hal.testsuite.fragment.config.resourceadapters.ConfigPropertiesFragment;
+/**
+ * Created by jkasik on 5.8.15.
+ */
+public class JGroupsConfigArea extends ConfigAreaFragment {
+
+    public ConfigPropertiesFragment propertiesConfig() {
+        return switchTo("Properties", ConfigPropertiesFragment.class);
+    }
+
+}

--- a/src/main/java/org/jboss/hal/testsuite/page/config/JGroupsPage.java
+++ b/src/main/java/org/jboss/hal/testsuite/page/config/JGroupsPage.java
@@ -1,0 +1,46 @@
+package org.jboss.hal.testsuite.page.config;
+
+import org.jboss.arquillian.graphene.Graphene;
+import org.jboss.arquillian.graphene.findby.ByJQuery;
+import org.jboss.arquillian.graphene.page.Location;
+import org.jboss.hal.testsuite.fragment.config.jgroups.ExecutorTabFragment;
+import org.jboss.hal.testsuite.fragment.config.resourceadapters.ConfigPropertiesFragment;
+import org.jboss.hal.testsuite.util.Console;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Created by jkasik on 22.7.15.
+ */
+@Location("#jgroups")
+public class JGroupsPage extends ConfigurationPage {
+
+    public void selectStackByName(String name) {
+        getResourceManager().getResourceTable().getRowByText(0, name).view();
+    }
+
+    public void openExecutors() {
+        By parent = ByJQuery.selector("table.gwt-DisclosurePanel.default-disclosure");
+        WebElement root = getContentRoot().findElement(parent);
+        ExecutorTabFragment executorTabFragment = Graphene.createPageFragment(ExecutorTabFragment.class, root);
+        executorTabFragment.openExecutors();
+    }
+    
+    public void switchToTransport() {
+        switchTo("Transport");
+    }
+
+    public void switchToProtocols() {
+        switchTo("Protocols");
+    }
+
+    public void switchTo(String name) {
+        switchView(name);
+        Console.withBrowser(browser).waitUntilLoaded();
+    }
+
+    public ConfigPropertiesFragment getConfigProperties() {
+        return Graphene.createPageFragment(ConfigPropertiesFragment.class, getContentRoot());
+    }
+
+}

--- a/src/main/java/org/jboss/hal/testsuite/page/config/JGroupsPage.java
+++ b/src/main/java/org/jboss/hal/testsuite/page/config/JGroupsPage.java
@@ -4,7 +4,7 @@ import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.graphene.findby.ByJQuery;
 import org.jboss.arquillian.graphene.page.Location;
 import org.jboss.hal.testsuite.fragment.config.jgroups.ExecutorTabFragment;
-import org.jboss.hal.testsuite.fragment.config.resourceadapters.ConfigPropertiesFragment;
+import org.jboss.hal.testsuite.fragment.config.jgroups.JGroupsConfigArea;
 import org.jboss.hal.testsuite.util.Console;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -25,7 +25,7 @@ public class JGroupsPage extends ConfigurationPage {
         ExecutorTabFragment executorTabFragment = Graphene.createPageFragment(ExecutorTabFragment.class, root);
         executorTabFragment.openExecutors();
     }
-    
+
     public void switchToTransport() {
         switchTo("Transport");
     }
@@ -34,13 +34,18 @@ public class JGroupsPage extends ConfigurationPage {
         switchTo("Protocols");
     }
 
+    public void switchToProtocol(String protocol) {
+        switchToProtocols();
+        getResourceManager().getResourceTable().getRowByText(0, protocol).click();
+    }
+
     public void switchTo(String name) {
         switchView(name);
         Console.withBrowser(browser).waitUntilLoaded();
     }
 
-    public ConfigPropertiesFragment getConfigProperties() {
-        return Graphene.createPageFragment(ConfigPropertiesFragment.class, getContentRoot());
+    public JGroupsConfigArea getConfig() {
+        return getConfig(JGroupsConfigArea.class);
     }
 
 }

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
@@ -16,10 +16,7 @@ import org.jboss.hal.testsuite.test.util.ConfigAreaChecker;
 import org.jboss.hal.testsuite.util.ConfigUtils;
 import org.jboss.hal.testsuite.util.Console;
 import org.jboss.hal.testsuite.util.ResourceVerifier;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.openqa.selenium.WebDriver;
 
 import static org.junit.Assert.assertFalse;
@@ -36,6 +33,7 @@ public class JGroupAbstractTestCase {
     protected static final String PROPERTY_VALUE = "url";
     protected static final String PROPERTY_NAME_P = "URL1";
     protected static final String PROPERTY_VALUE_P = "url1";
+    protected static final String DEFAULT_PROTOCOL = "UNICAST3";
 
     private static CliClient client = CliClientFactory.getClient();
     protected static ResourceVerifier verifier = new ResourceVerifier("", client);
@@ -56,20 +54,23 @@ public class JGroupAbstractTestCase {
     public void navigateInDomain() {
         Graphene.goTo(DomainConfigurationPage.class);
         Console.withBrowser(browser).waitUntilLoaded();
-        page.select("Profiles").select("full-ha").view("JGroups");
+        page.selectMenu("Profiles").selectMenu("full-ha").view("JGroups");
         Console.withBrowser(browser).waitUntilLoaded();
     }
 
     private void navigateInStandalone() {
         Graphene.goTo(StandaloneConfigurationPage.class);
         Console.withBrowser(browser).waitUntilLoaded();
-        page.select("Subsystems").view("JGroups");
+        page.selectMenu("Subsystems").view("JGroups");
         Console.withBrowser(browser).waitUntilLoaded();
     }
 
     @Before
     public void before() {
-        if (!initialized) { onlyOnce(); initialized = true;}
+        if (!initialized) {
+            onlyOnce();
+            initialized = true;
+        }
         Graphene.goTo(HomePage.class);
         Console.withBrowser(browser).waitUntilLoaded();
         if (ConfigUtils.isDomain()) {
@@ -77,19 +78,21 @@ public class JGroupAbstractTestCase {
         } else {
             navigateInStandalone();
         }
+        Console.withBrowser(browser).waitUntilLoaded();
     }
 
     @After
     public void after() {
         Console.withBrowser(browser).refresh();
+        Console.withBrowser(browser).waitUntilLoaded();
     }
 
     @AfterClass
     public static void tearDown() {
         jGroupsOperations.removeTransportProperty(PROPERTY_NAME, PROPERTY_VALUE);
         jGroupsOperations.removeTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P);
-        jGroupsOperations.removeProtocolProperty(PROPERTY_NAME);
-        jGroupsOperations.removeProtocolProperty(PROPERTY_NAME_P);
+        jGroupsOperations.removeProtocolProperty(DEFAULT_PROTOCOL, PROPERTY_NAME);
+        jGroupsOperations.removeProtocolProperty(DEFAULT_PROTOCOL, PROPERTY_NAME_P);
     }
 
     @Test
@@ -128,6 +131,7 @@ public class JGroupAbstractTestCase {
         checker.editTextAndAssert(page, "rack", name).invoke();
     }
 
+    @Ignore("Executor tab removed in DR7")
     @Test
     public void threadFactoryEdit() {
         String name = RandomStringUtils.randomAlphabetic(6);
@@ -135,6 +139,7 @@ public class JGroupAbstractTestCase {
         checker.editTextAndAssert(page, "threadFactory", name).dmrAttribute("thread-factory").invoke();
     }
 
+    @Ignore("Executor tab removed in DR7")
     @Test
     public void defaultExecutorEdit() {
         String name = RandomStringUtils.randomAlphabetic(6);
@@ -142,6 +147,7 @@ public class JGroupAbstractTestCase {
         checker.editTextAndAssert(page, "defaultExecutor", name).dmrAttribute("default-executor").invoke();
     }
 
+    @Ignore("Executor tab removed in DR7")
     @Test
     public void oobExecutorEdit() {
         String name = RandomStringUtils.randomAlphabetic(6);
@@ -149,6 +155,7 @@ public class JGroupAbstractTestCase {
         checker.editTextAndAssert(page, "oobExecutor", name).dmrAttribute("oob-executor").invoke();
     }
 
+    @Ignore("Executor tab removed in DR7")
     @Test
     public void timerExecutorEdit() {
         String name = RandomStringUtils.randomAlphabetic(6);
@@ -158,7 +165,7 @@ public class JGroupAbstractTestCase {
 
     @Test
     public void createTransportProperty() {
-        ConfigPropertiesFragment properties = page.getConfigProperties();
+        ConfigPropertiesFragment properties = page.getConfig().propertiesConfig();
         ConfigPropertyWizard wizard = properties.addProperty();
         wizard.name(PROPERTY_NAME).value(PROPERTY_VALUE).finish();
         assertTrue(jGroupsOperations.verifyTransportProperty(PROPERTY_NAME, PROPERTY_VALUE));
@@ -166,25 +173,26 @@ public class JGroupAbstractTestCase {
 
     @Test
     public void removeTransportProperty() {
-        ConfigPropertiesFragment properties = page.getConfigProperties();
+        ConfigPropertiesFragment properties = page.getConfig().propertiesConfig();
         properties.removeProperty(PROPERTY_NAME_P);
         assertFalse(jGroupsOperations.verifyTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P));
     }
 
+
     @Test
-    public void createProtocolProperty() {//TODO
-        page.switchToProtocols();
-        ConfigPropertiesFragment properties = page.getConfigProperties();
+    public void createProtocolProperty() {
+        page.switchToProtocol(DEFAULT_PROTOCOL);
+        ConfigPropertiesFragment properties = page.getConfig().propertiesConfig();
         ConfigPropertyWizard wizard = properties.addProperty();
         wizard.name(PROPERTY_NAME).value(PROPERTY_VALUE).finish();
-        assertTrue(jGroupsOperations.verifyProtocolProperty(PROPERTY_NAME, PROPERTY_VALUE));
+        assertTrue(jGroupsOperations.verifyProtocolProperty(DEFAULT_PROTOCOL, PROPERTY_NAME, PROPERTY_VALUE));
     }
 
     @Test
-    public void removeProtocolProperty() {//TODO
-        page.switchToProtocols();
-        ConfigPropertiesFragment properties = page.getConfigProperties();
+    public void removeProtocolProperty() {
+        page.switchToProtocol(DEFAULT_PROTOCOL);
+        ConfigPropertiesFragment properties = page.getConfig().propertiesConfig();
         properties.removeProperty(PROPERTY_NAME_P);
-        assertFalse(jGroupsOperations.verifyProtocolProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P));
+        assertFalse(jGroupsOperations.verifyProtocolProperty(DEFAULT_PROTOCOL, PROPERTY_NAME_P, PROPERTY_VALUE_P));
     }
 }

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
@@ -88,6 +88,8 @@ public class JGroupAbstractTestCase {
     public static void tearDown() {
         jGroupsOperations.removeTransportProperty(PROPERTY_NAME, PROPERTY_VALUE);
         jGroupsOperations.removeTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P);
+        jGroupsOperations.removeProtocolProperty(PROPERTY_NAME);
+        jGroupsOperations.removeProtocolProperty(PROPERTY_NAME_P);
     }
 
     @Test
@@ -175,7 +177,7 @@ public class JGroupAbstractTestCase {
         ConfigPropertiesFragment properties = page.getConfigProperties();
         ConfigPropertyWizard wizard = properties.addProperty();
         wizard.name(PROPERTY_NAME).value(PROPERTY_VALUE).finish();
-        assertTrue(jGroupsOperations.verifyTransportProperty(PROPERTY_NAME, PROPERTY_VALUE));
+        assertTrue(jGroupsOperations.verifyProtocolProperty(PROPERTY_NAME, PROPERTY_VALUE));
     }
 
     @Test
@@ -183,6 +185,6 @@ public class JGroupAbstractTestCase {
         page.switchToProtocols();
         ConfigPropertiesFragment properties = page.getConfigProperties();
         properties.removeProperty(PROPERTY_NAME_P);
-        assertFalse(jGroupsOperations.verifyTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P));
+        assertFalse(jGroupsOperations.verifyProtocolProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P));
     }
 }

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
@@ -1,0 +1,188 @@
+package org.jboss.hal.testsuite.test.configuration.jgroups;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.Graphene;
+import org.jboss.arquillian.graphene.page.Page;
+import org.jboss.hal.testsuite.cli.CliClient;
+import org.jboss.hal.testsuite.cli.CliClientFactory;
+import org.jboss.hal.testsuite.fragment.config.resourceadapters.ConfigPropertiesFragment;
+import org.jboss.hal.testsuite.fragment.config.resourceadapters.ConfigPropertyWizard;
+import org.jboss.hal.testsuite.page.config.DomainConfigurationPage;
+import org.jboss.hal.testsuite.page.config.JGroupsPage;
+import org.jboss.hal.testsuite.page.config.StandaloneConfigurationPage;
+import org.jboss.hal.testsuite.page.home.HomePage;
+import org.jboss.hal.testsuite.test.util.ConfigAreaChecker;
+import org.jboss.hal.testsuite.util.ConfigUtils;
+import org.jboss.hal.testsuite.util.Console;
+import org.jboss.hal.testsuite.util.ResourceVerifier;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebDriver;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by jkasik <jkasik@redhat.com>
+ */
+public class JGroupAbstractTestCase {
+
+    private static boolean initialized = false;
+
+    protected static final String PROPERTY_NAME = "URL";
+    protected static final String PROPERTY_VALUE = "url";
+    protected static final String PROPERTY_NAME_P = "URL1";
+    protected static final String PROPERTY_VALUE_P = "url1";
+
+    private static CliClient client = CliClientFactory.getClient();
+    protected static ResourceVerifier verifier = new ResourceVerifier("", client);
+    private ConfigAreaChecker checker = new ConfigAreaChecker(verifier);
+    protected static JGroupsOperations jGroupsOperations = new JGroupsOperations(client);
+
+    @Drone
+    public WebDriver browser;
+
+    @Page
+    public JGroupsPage page;
+
+
+    public void onlyOnce() {
+        Console.withBrowser(browser).maximizeWindow();
+    }
+
+    public void navigateInDomain() {
+        Graphene.goTo(DomainConfigurationPage.class);
+        Console.withBrowser(browser).waitUntilLoaded();
+        page.select("Profiles").select("full-ha").view("JGroups");
+        Console.withBrowser(browser).waitUntilLoaded();
+    }
+
+    private void navigateInStandalone() {
+        Graphene.goTo(StandaloneConfigurationPage.class);
+        Console.withBrowser(browser).waitUntilLoaded();
+        page.select("Subsystems").view("JGroups");
+        Console.withBrowser(browser).waitUntilLoaded();
+    }
+
+    @Before
+    public void before() {
+        if (!initialized) { onlyOnce(); initialized = true;}
+        Graphene.goTo(HomePage.class);
+        Console.withBrowser(browser).waitUntilLoaded();
+        if (ConfigUtils.isDomain()) {
+            navigateInDomain();
+        } else {
+            navigateInStandalone();
+        }
+    }
+
+    @After
+    public void after() {
+        Console.withBrowser(browser).refresh();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        jGroupsOperations.removeTransportProperty(PROPERTY_NAME, PROPERTY_VALUE);
+        jGroupsOperations.removeTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P);
+    }
+
+    @Test
+    public void socketBindingEdit() {
+        String name = RandomStringUtils.randomAlphabetic(6);
+        checker.editTextAndAssert(page, "socketBinding", name).dmrAttribute("socket-binding").invoke();
+    }
+
+    @Test
+    public void diagnosticSocketEdit() {
+        String name = RandomStringUtils.randomAlphabetic(6);
+        checker.editTextAndAssert(page, "diagSocketBinding", name)
+                .dmrAttribute("diagnostics-socket-binding").invoke();
+    }
+
+    @Test
+    public void machineEdit() {
+        String name = RandomStringUtils.randomAlphabetic(6);
+        checker.editTextAndAssert(page, "machine", name).dmrAttribute("machine").invoke();
+    }
+
+    @Test
+    public void sharedStatusEdit() {
+        checker.editCheckboxAndAssert(page, "shared", true).dmrAttribute("shared").invoke();
+    }
+
+    @Test
+    public void siteEdit() {
+        String name = RandomStringUtils.randomAlphabetic(6);
+        checker.editTextAndAssert(page, "site", name).invoke();
+    }
+
+    @Test
+    public void rackEdit() {
+        String name = RandomStringUtils.randomAlphabetic(6);
+        checker.editTextAndAssert(page, "rack", name).invoke();
+    }
+
+    @Test
+    public void threadFactoryEdit() {
+        String name = RandomStringUtils.randomAlphabetic(6);
+        page.openExecutors();
+        checker.editTextAndAssert(page, "threadFactory", name).dmrAttribute("thread-factory").invoke();
+    }
+
+    @Test
+    public void defaultExecutorEdit() {
+        String name = RandomStringUtils.randomAlphabetic(6);
+        page.openExecutors();
+        checker.editTextAndAssert(page, "defaultExecutor", name).dmrAttribute("default-executor").invoke();
+    }
+
+    @Test
+    public void oobExecutorEdit() {
+        String name = RandomStringUtils.randomAlphabetic(6);
+        page.openExecutors();
+        checker.editTextAndAssert(page, "oobExecutor", name).dmrAttribute("oob-executor").invoke();
+    }
+
+    @Test
+    public void timerExecutorEdit() {
+        String name = RandomStringUtils.randomAlphabetic(6);
+        page.openExecutors();
+        checker.editTextAndAssert(page, "timerExecutor", name).dmrAttribute("timer-executor").invoke();
+    }
+
+    @Test
+    public void createTransportProperty() {
+        ConfigPropertiesFragment properties = page.getConfigProperties();
+        ConfigPropertyWizard wizard = properties.addProperty();
+        wizard.name(PROPERTY_NAME).value(PROPERTY_VALUE).finish();
+        assertTrue(jGroupsOperations.verifyTransportProperty(PROPERTY_NAME, PROPERTY_VALUE));
+    }
+
+    @Test
+    public void removeTransportProperty() {
+        ConfigPropertiesFragment properties = page.getConfigProperties();
+        properties.removeProperty(PROPERTY_NAME_P);
+        assertFalse(jGroupsOperations.verifyTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P));
+    }
+
+    @Test
+    public void createProtocolProperty() {//TODO
+        page.switchToProtocols();
+        ConfigPropertiesFragment properties = page.getConfigProperties();
+        ConfigPropertyWizard wizard = properties.addProperty();
+        wizard.name(PROPERTY_NAME).value(PROPERTY_VALUE).finish();
+        assertTrue(jGroupsOperations.verifyTransportProperty(PROPERTY_NAME, PROPERTY_VALUE));
+    }
+
+    @Test
+    public void removeProtocolProperty() {//TODO
+        page.switchToProtocols();
+        ConfigPropertiesFragment properties = page.getConfigProperties();
+        properties.removeProperty(PROPERTY_NAME_P);
+        assertFalse(jGroupsOperations.verifyTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P));
+    }
+}

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupTCPTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupTCPTestCase.java
@@ -21,6 +21,7 @@ public class JGroupTCPTestCase extends JGroupAbstractTestCase {
         jGroupsOperations.setStackName("tcp");
         jGroupsOperations.setTransport("TCP");
         jGroupsOperations.addTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P);
+        jGroupsOperations.addProtocolProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P);
     }
 
     @Before

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupTCPTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupTCPTestCase.java
@@ -1,0 +1,32 @@
+package org.jboss.hal.testsuite.test.configuration.jgroups;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.hal.testsuite.test.category.Shared;
+import org.jboss.hal.testsuite.util.Console;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Created by jkasik <jkasik@redhat.com>
+ */
+@RunWith(Arquillian.class)
+@Category(Shared.class)
+public class JGroupTCPTestCase extends JGroupAbstractTestCase {
+
+    @BeforeClass
+    public static void setUpTCP() {
+        verifier.setDmrPath("/profile=full-ha/subsystem=jgroups/stack=tcp/transport=TCP");
+        jGroupsOperations.setStackName("tcp");
+        jGroupsOperations.setTransport("TCP");
+        jGroupsOperations.addTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P);
+    }
+
+    @Before
+    public void beforeTCP() {
+        page.selectStackByName("tcp");
+        Console.withBrowser(browser).waitUntilLoaded();
+        page.switchToTransport();
+    }
+}

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupTCPTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupTCPTestCase.java
@@ -1,7 +1,8 @@
 package org.jboss.hal.testsuite.test.configuration.jgroups;
 
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.hal.testsuite.test.category.Shared;
+import org.jboss.hal.testsuite.category.Shared;
+import org.jboss.hal.testsuite.util.ConfigUtils;
 import org.jboss.hal.testsuite.util.Console;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -17,11 +18,14 @@ public class JGroupTCPTestCase extends JGroupAbstractTestCase {
 
     @BeforeClass
     public static void setUpTCP() {
-        verifier.setDmrPath("/profile=full-ha/subsystem=jgroups/stack=tcp/transport=TCP");
-        jGroupsOperations.setStackName("tcp");
+        String profile = "";
+        if (ConfigUtils.isDomain())
+            profile = "/profile=full-ha";
+        verifier.setDmrPath(profile + "/subsystem=jgroups/stack=tcp/transport=TCP");
+        jGroupsOperations.setBaseDrmPath(profile + "/subsystem=jgroups/stack=tcp/");
         jGroupsOperations.setTransport("TCP");
         jGroupsOperations.addTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P);
-        jGroupsOperations.addProtocolProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P);
+        jGroupsOperations.addProtocolProperty(DEFAULT_PROTOCOL, PROPERTY_NAME_P, PROPERTY_VALUE_P);
     }
 
     @Before
@@ -29,5 +33,6 @@ public class JGroupTCPTestCase extends JGroupAbstractTestCase {
         page.selectStackByName("tcp");
         Console.withBrowser(browser).waitUntilLoaded();
         page.switchToTransport();
+        Console.withBrowser(browser).waitUntilLoaded();
     }
 }

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupUDPTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupUDPTestCase.java
@@ -1,0 +1,32 @@
+package org.jboss.hal.testsuite.test.configuration.jgroups;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.hal.testsuite.test.category.Shared;
+import org.jboss.hal.testsuite.util.Console;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Created by jkasik <jkasik@redhat.com>
+ */
+@RunWith(Arquillian.class)
+@Category(Shared.class)
+public class JGroupUDPTestCase extends JGroupAbstractTestCase {
+
+    @BeforeClass
+    public static void setUpUDP() {
+        verifier.setDmrPath("/subsystem=jgroups/stack=udp/transport=UDP");
+        jGroupsOperations.setStackName("udp");
+        jGroupsOperations.setTransport("UDP");
+        jGroupsOperations.addTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P);
+    }
+
+    @Before
+    public void beforeUDP() {
+        page.selectStackByName("udp");
+        Console.withBrowser(browser).waitUntilLoaded();
+        page.switchToTransport();
+    }
+}

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupUDPTestCase.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupUDPTestCase.java
@@ -1,7 +1,8 @@
 package org.jboss.hal.testsuite.test.configuration.jgroups;
 
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.hal.testsuite.test.category.Shared;
+import org.jboss.hal.testsuite.category.Shared;
+import org.jboss.hal.testsuite.util.ConfigUtils;
 import org.jboss.hal.testsuite.util.Console;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -17,10 +18,15 @@ public class JGroupUDPTestCase extends JGroupAbstractTestCase {
 
     @BeforeClass
     public static void setUpUDP() {
-        verifier.setDmrPath("/subsystem=jgroups/stack=udp/transport=UDP");
-        jGroupsOperations.setStackName("udp");
+        String profile = "";
+        if (ConfigUtils.isDomain()) {
+            profile = "/profile=full-ha";
+        }
+        verifier.setDmrPath(profile + "/subsystem=jgroups/stack=udp/transport=UDP");
+        jGroupsOperations.setBaseDrmPath(profile + "/subsystem=jgroups/stack=udp/");
         jGroupsOperations.setTransport("UDP");
         jGroupsOperations.addTransportProperty(PROPERTY_NAME_P, PROPERTY_VALUE_P);
+        jGroupsOperations.addProtocolProperty(DEFAULT_PROTOCOL, PROPERTY_NAME_P, PROPERTY_VALUE_P);
     }
 
     @Before

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupsOperations.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupsOperations.java
@@ -78,15 +78,15 @@ public class JGroupsOperations {
 
     /*protocol properties*/
 
-    public boolean addProtocolProperty(String protocol, String name, String value) {//TODO: verify
+    public boolean addProtocolProperty(String protocol, String name, String value) {
         return addProperty(getProtocolDrmPath(protocol), name, value);
     }
 
-    public boolean verifyProtocolProperty(String protocol, String name, String value) {//todo verify
+    public boolean verifyProtocolProperty(String protocol, String name, String value) {
         return verifyProperty(getProtocolDrmPath(protocol), name, value);
     }
 
-    public void removeProtocolProperty(String protocol, String name) {//todo verify
+    public void removeProtocolProperty(String protocol, String name) {
         removeProperty(getProtocolDrmPath(protocol), name);
     }
 }

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupsOperations.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupsOperations.java
@@ -10,32 +10,11 @@ import org.jboss.hal.testsuite.util.ConfigUtils;
 public class JGroupsOperations {
 
     private CliClient client;
-    private String profile = "";
-    private String stackName = "";
     private String transport = "";
-    private String protocol = "";
-
-    public JGroupsOperations(CliClient client, String stackName, String transport, String protocol) {
-        this(client);
-        this.stackName = stackName;
-        this.transport = transport;
-        this.protocol = protocol;
-    }
+    private String baseDrmPath = "";
 
     public JGroupsOperations(CliClient client) {
         this.client = client;
-        if (ConfigUtils.isDomain()) {
-            profile = "/profile=full-ha";
-        }
-        protocol = "";//TODO: default protocol name
-    }
-
-    public String getStackName() {
-        return stackName;
-    }
-
-    public void setStackName(String stackName) {
-        this.stackName = stackName;
     }
 
     public String getTransport() {
@@ -47,17 +26,19 @@ public class JGroupsOperations {
     }
 
     private String getBaseDmrPath() {
-        return  profile +
-                "/subsystem=jgroups/" +
-                "stack=" + stackName + "/";
+        return baseDrmPath;
+    }
+
+    public void setBaseDrmPath(String baseDrmPath) {
+        this.baseDrmPath = baseDrmPath;
     }
 
     private String getTransportDrmPath() {
         return getBaseDmrPath() + "transport=" + transport + "/";
     }
 
-    private String getProtocolDrmPath() {//TODO: verify
-        return getBaseDmrPath() + "protocol=" + protocol + "/";
+    private String getProtocolDrmPath(String name) {//TODO: verify
+        return getBaseDmrPath() + "protocol=" + name + "/";
     }
 
     /**/
@@ -97,15 +78,15 @@ public class JGroupsOperations {
 
     /*protocol properties*/
 
-    public boolean addProtocolProperty(String name, String value) {//TODO: verify
-        return addProperty(getProtocolDrmPath(), name, value);
+    public boolean addProtocolProperty(String protocol, String name, String value) {//TODO: verify
+        return addProperty(getProtocolDrmPath(protocol), name, value);
     }
 
-    public boolean verifyProtocolProperty(String name, String value) {//todo verify
-        return verifyProperty(getProtocolDrmPath(), name, value);
+    public boolean verifyProtocolProperty(String protocol, String name, String value) {//todo verify
+        return verifyProperty(getProtocolDrmPath(protocol), name, value);
     }
 
-    public void removeProtocolProperty(String name) {//todo verify
-        removeProperty(getProtocolDrmPath(), name);
+    public void removeProtocolProperty(String protocol, String name) {//todo verify
+        removeProperty(getProtocolDrmPath(protocol), name);
     }
 }

--- a/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupsOperations.java
+++ b/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupsOperations.java
@@ -1,0 +1,94 @@
+package org.jboss.hal.testsuite.test.configuration.jgroups;
+
+import org.jboss.as.cli.scriptsupport.CLI;
+import org.jboss.hal.testsuite.cli.CliClient;
+import org.jboss.hal.testsuite.util.ConfigUtils;
+
+/**
+ * Created by jkasik on 23.7.15.
+ */
+public class JGroupsOperations {
+
+    private CliClient client;
+    private String profile = "";
+    private String stackName = "";
+    private String transport = "";
+
+    public JGroupsOperations(CliClient client, String stackName, String transport) {
+        this(client);
+        this.stackName = stackName;
+        this.transport = transport;
+    }
+
+    public JGroupsOperations(CliClient client) {
+        this.client = client;
+        if (ConfigUtils.isDomain()) {
+            profile = "/profile=full-ha";
+        }
+    }
+
+    public String getStackName() {
+        return stackName;
+    }
+
+    public void setStackName(String stackName) {
+        this.stackName = stackName;
+    }
+
+    public String getTransport() {
+        return transport;
+    }
+
+    public void setTransport(String transport) {
+        this.transport = transport;
+    }
+
+    private String getBaseDmrPath() {
+        return  profile +
+                "/subsystem=jgroups/" +
+                "stack=" + stackName + "/";
+    }
+
+    private String getTransportDrmPath() {
+        return  getBaseDmrPath() + "transport=" + transport + "/";
+    }
+
+    /*transport properties*/
+
+    public boolean addTransportProperty(String name, String value) {
+        String command = getTransportDrmPath() + "property=" + name + ":add(value=" + value + ")";
+        CLI.Result result = client.executeCommand(command);
+        return result.isSuccess();
+    }
+
+    public void removeTransportProperty(String name, String value) {
+        String command = getTransportDrmPath() + "property=" + name + ":remove";
+        client.executeCommand(command);
+    }
+
+    public boolean verifyTransportProperty(String name, String value) {
+        String command = getTransportDrmPath() + ":read-resource";
+        CLI.Result result = client.executeCommand(command);
+        return result.getResponse()
+                .get("result")
+                .get("properties")
+                .toJSONString(false)
+                .contains("\"" + name + "\" : \"" + value + "\"");
+    }
+
+    /*protocol properties*/
+
+    public boolean addProtocolProperty(String name, String value) {
+        //TODO
+        return false;
+    }
+
+    public boolean verifyProtocolProperty(String name, String value) {
+        //TODO
+        return false;
+    }
+
+    public void removeProtocolProperty() {
+        //TODO
+    }
+}


### PR DESCRIPTION
Updated JGroups test for current testsuite.
There was an executor setting in settings in DR6 but it is not present in DR7. I just added Ignore annotation for now - if it is not coming back, I can remove it completely.
