### PR TITLE
Added identifiers to randomly generated strings

### DIFF
--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/container/EJB3ServiceTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/container/EJB3ServiceTestCase.java
@@ -92,7 +92,7 @@ public class EJB3ServiceTestCase {
     }
 
     private String createThreadPool() {
-        String name = RandomStringUtils.randomAlphanumeric(5);
+        String name = "threadPool" + RandomStringUtils.randomAlphanumeric(5);
         client.executeCommand(CliUtils.buildCommand(CliConstants.EJB3_THREAD_POOL_ADDRESS + "=" + name, ":add", new String[]{"max-threads=30", "keepalive-time={time=30, unit=MINUTES}"}));
         return name;
     }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/container/EJB3ServiceTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/container/EJB3ServiceTestCase.java
@@ -92,7 +92,7 @@ public class EJB3ServiceTestCase {
     }
 
     private String createThreadPool() {
-        String name = "threadPool" + RandomStringUtils.randomAlphanumeric(5);
+        String name = "EJB3ServiceThreadPool_" + RandomStringUtils.randomAlphanumeric(5);
         client.executeCommand(CliUtils.buildCommand(CliConstants.EJB3_THREAD_POOL_ADDRESS + "=" + name, ":add", new String[]{"max-threads=30", "keepalive-time={time=30, unit=MINUTES}"}));
         return name;
     }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/container/EJB3ThreadPoolTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/container/EJB3ThreadPoolTestCase.java
@@ -85,7 +85,7 @@ public class EJB3ThreadPoolTestCase {
 
     @Test
     public void createThreadPool() {
-        String name = "threadPool2" + RandomStringUtils.randomAlphanumeric(8);
+        String name = "EJB3ThreadPoolThreadPool_" + RandomStringUtils.randomAlphanumeric(8);
         ResourceAddress address = ADDRESS_TEMPLATE.resolve(statementContext, name);
         dispatcher.execute(new Operation.Builder(ModelDescriptionConstants.ADD, address).param("max-threads", 99).build());
 
@@ -110,7 +110,7 @@ public class EJB3ThreadPoolTestCase {
 
     @Test
     public void editMaxThreads() {
-        String name = "maxThreads_" + RandomStringUtils.randomAlphanumeric(8);
+        String name = "EJB3ThreadPoolMaxThreads_" + RandomStringUtils.randomAlphanumeric(8);
         ResourceAddress address = ADDRESS_TEMPLATE.resolve(statementContext, name);
         dispatcher.execute(new Operation.Builder("add", address).param("max-threads", 99).build());
 
@@ -131,7 +131,7 @@ public class EJB3ThreadPoolTestCase {
 
     @Test
     public void removeBeanPool() {
-        String name = "beanPool_" + RandomStringUtils.randomAlphanumeric(8);
+        String name = "EJB3ThreadPoolBeanPool_" + RandomStringUtils.randomAlphanumeric(8);
         ResourceAddress address = ADDRESS_TEMPLATE.resolve(statementContext, name);
         dispatcher.execute(new Operation.Builder("add", address).param("max-threads", 99).build());
 
@@ -150,7 +150,7 @@ public class EJB3ThreadPoolTestCase {
 
     @Test
     public void createThreadPoolWithoutMaxThreads() {
-        String name = "ThreadPool_" + RandomStringUtils.randomAlphanumeric(20);
+        String name = "EJB3ThreadPoolThreadPool2_" + RandomStringUtils.randomAlphanumeric(20);
         ResourceAddress address = ADDRESS_TEMPLATE.resolve(statementContext, name);
 
         finderNavigation.selectRow().invoke(FinderNames.VIEW);

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/container/EJB3ThreadPoolTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/container/EJB3ThreadPoolTestCase.java
@@ -85,7 +85,7 @@ public class EJB3ThreadPoolTestCase {
 
     @Test
     public void createThreadPool() {
-        String name = RandomStringUtils.randomAlphanumeric(8);
+        String name = "threadPool2" + RandomStringUtils.randomAlphanumeric(8);
         ResourceAddress address = ADDRESS_TEMPLATE.resolve(statementContext, name);
         dispatcher.execute(new Operation.Builder(ModelDescriptionConstants.ADD, address).param("max-threads", 99).build());
 
@@ -110,7 +110,7 @@ public class EJB3ThreadPoolTestCase {
 
     @Test
     public void editMaxThreads() {
-        String name = RandomStringUtils.randomAlphanumeric(8);
+        String name = "maxThreads_" + RandomStringUtils.randomAlphanumeric(8);
         ResourceAddress address = ADDRESS_TEMPLATE.resolve(statementContext, name);
         dispatcher.execute(new Operation.Builder("add", address).param("max-threads", 99).build());
 
@@ -131,7 +131,7 @@ public class EJB3ThreadPoolTestCase {
 
     @Test
     public void removeBeanPool() {
-        String name = RandomStringUtils.randomAlphanumeric(8);
+        String name = "beanPool_" + RandomStringUtils.randomAlphanumeric(8);
         ResourceAddress address = ADDRESS_TEMPLATE.resolve(statementContext, name);
         dispatcher.execute(new Operation.Builder("add", address).param("max-threads", 99).build());
 
@@ -150,7 +150,7 @@ public class EJB3ThreadPoolTestCase {
 
     @Test
     public void createThreadPoolWithoutMaxThreads() {
-        String name = RandomStringUtils.randomAlphanumeric(20);
+        String name = "ThreadPool_" + RandomStringUtils.randomAlphanumeric(20);
         ResourceAddress address = ADDRESS_TEMPLATE.resolve(statementContext, name);
 
         finderNavigation.selectRow().invoke(FinderNames.VIEW);

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/container/IIOPTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/container/IIOPTestCase.java
@@ -67,8 +67,8 @@ import static org.junit.Assert.assertTrue;
 public class IIOPTestCase {
 
     private static final Logger log = LoggerFactory.getLogger(IIOPTestCase.class);
-    private static final String KEY_VALUE = RandomStringUtils.randomAlphanumeric(5);
-    private static final String VALUE = RandomStringUtils.randomAlphanumeric(5);
+    private static final String KEY_VALUE = "IIOPKey_" +  RandomStringUtils.randomAlphanumeric(5);
+    private static final String VALUE = "IIOPValue_" + RandomStringUtils.randomAlphanumeric(5);
 
     @Drone WebDriver browser;
     private FinderNavigation navigation;

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/DataSourcesOperations.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/DataSourcesOperations.java
@@ -47,7 +47,7 @@ public class DataSourcesOperations {
     }
 
     public String createDataSource(String url) {
-        String name = RandomStringUtils.randomAlphanumeric(5);
+        String name = "dsOps_" + RandomStringUtils.randomAlphanumeric(5);
         return createDataSource(name, url);
     }
 
@@ -64,7 +64,7 @@ public class DataSourcesOperations {
     }
 
     public String createXADataSource(String url) {
-        String name = RandomStringUtils.randomAlphanumeric(5);
+        String name = "XAdsOps_" + RandomStringUtils.randomAlphanumeric(5);
         return createXADataSource(name, url);
     }
 

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/TestConnectionTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/TestConnectionTestCase.java
@@ -25,10 +25,10 @@ import org.junit.runner.RunWith;
 @Category(Shared.class)
 public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
 
-    private static String dsNameValid = RandomStringUtils.randomAlphanumeric(5);
-    private static String xaDsNameValid = RandomStringUtils.randomAlphanumeric(5);
-    private static String dsNameInvalid = RandomStringUtils.randomAlphanumeric(5);
-    private static String xaDsNameInvalid = RandomStringUtils.randomAlphanumeric(5);
+    private static String dsNameValid = "dsNameValid" + RandomStringUtils.randomAlphanumeric(5);
+    private static String xaDsNameValid = "xaDsNameValid" + RandomStringUtils.randomAlphanumeric(5);
+    private static String dsNameInvalid = "dsNameInvalid" + RandomStringUtils.randomAlphanumeric(5);
+    private static String xaDsNameInvalid = "xaDsNameInvalid" + RandomStringUtils.randomAlphanumeric(5);
 
     private static final String VALID_URL = "jdbc:h2:mem:test2;DB_CLOSE_DELAY=-1";
     private static final String INVALID_URL = "invalidUrl";
@@ -85,13 +85,13 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
 
     @Test
     public void validInWizard() {
-        String name = RandomStringUtils.randomAlphabetic(6);
+        String name = "validInWizard_" + RandomStringUtils.randomAlphabetic(6);
         testConnectionInWizard(dsOps, name, VALID_URL, true);
     }
 
     @Test
     public void invalidInWizard() {
-        String name = RandomStringUtils.randomAlphabetic(6);
+        String name = "invalidInWizard_" + RandomStringUtils.randomAlphabetic(6);
         testConnectionInWizard(dsOps, name, INVALID_URL, false);
     }
 
@@ -115,7 +115,7 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
     public void validXAInWizard() {
         datasourcesPage.switchToXA();
 
-        String name = RandomStringUtils.randomAlphabetic(6);
+        String name = "validXAInWizard_" + RandomStringUtils.randomAlphabetic(6);
         testXAConnectionInWizard(dsOps, name, VALID_URL, true);
     }
 
@@ -123,7 +123,7 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
     public void invalidXAInWizard() {
         datasourcesPage.switchToXA();
 
-        String name = RandomStringUtils.randomAlphabetic(6);
+        String name = "invalidXAInWizard_" + RandomStringUtils.randomAlphabetic(6);
         testXAConnectionInWizard(dsOps, name, "invalidUrl", false);
     }
 }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/TestConnectionTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/datasources/TestConnectionTestCase.java
@@ -25,10 +25,10 @@ import org.junit.runner.RunWith;
 @Category(Shared.class)
 public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
 
-    private static String dsNameValid = "dsNameValid" + RandomStringUtils.randomAlphanumeric(5);
-    private static String xaDsNameValid = "xaDsNameValid" + RandomStringUtils.randomAlphanumeric(5);
-    private static String dsNameInvalid = "dsNameInvalid" + RandomStringUtils.randomAlphanumeric(5);
-    private static String xaDsNameInvalid = "xaDsNameInvalid" + RandomStringUtils.randomAlphanumeric(5);
+    private static String dsNameValid = "TestConnectionDSNameValid" + RandomStringUtils.randomAlphanumeric(5);
+    private static String xaDsNameValid = "TestConnectionXADsNameValid" + RandomStringUtils.randomAlphanumeric(5);
+    private static String dsNameInvalid = "TestConnectionDSNameInvalid" + RandomStringUtils.randomAlphanumeric(5);
+    private static String xaDsNameInvalid = "TestConnectionXADsNameInvalid" + RandomStringUtils.randomAlphanumeric(5);
 
     private static final String VALID_URL = "jdbc:h2:mem:test2;DB_CLOSE_DELAY=-1";
     private static final String INVALID_URL = "invalidUrl";
@@ -85,13 +85,13 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
 
     @Test
     public void validInWizard() {
-        String name = "validInWizard_" + RandomStringUtils.randomAlphabetic(6);
+        String name = "TestConnectionValidInWizard_" + RandomStringUtils.randomAlphabetic(6);
         testConnectionInWizard(dsOps, name, VALID_URL, true);
     }
 
     @Test
     public void invalidInWizard() {
-        String name = "invalidInWizard_" + RandomStringUtils.randomAlphabetic(6);
+        String name = "TestConnectionInvalidInWizard_" + RandomStringUtils.randomAlphabetic(6);
         testConnectionInWizard(dsOps, name, INVALID_URL, false);
     }
 
@@ -115,7 +115,7 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
     public void validXAInWizard() {
         datasourcesPage.switchToXA();
 
-        String name = "validXAInWizard_" + RandomStringUtils.randomAlphabetic(6);
+        String name = "TestConnectionValidXAInWizard_" + RandomStringUtils.randomAlphabetic(6);
         testXAConnectionInWizard(dsOps, name, VALID_URL, true);
     }
 
@@ -123,7 +123,7 @@ public class TestConnectionTestCase extends AbstractTestConnectionTestCase {
     public void invalidXAInWizard() {
         datasourcesPage.switchToXA();
 
-        String name = "invalidXAInWizard_" + RandomStringUtils.randomAlphabetic(6);
+        String name = "TestConnectionInvalidXAInWizard_" + RandomStringUtils.randomAlphabetic(6);
         testXAConnectionInWizard(dsOps, name, "invalidUrl", false);
     }
 }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/ContextServicesTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/ContextServicesTestCase.java
@@ -39,7 +39,7 @@ public class ContextServicesTestCase extends EETestCaseAbstract {
     //values
     private final String JNDI_INVALID = "test";
     private final String JNDI_DEFAULT = "java:/";
-    private final String JNDI_VALID = JNDI_DEFAULT + RandomStringUtils.randomAlphanumeric(6);
+    private final String JNDI_VALID = JNDI_DEFAULT + "eeTestAbstract_" + RandomStringUtils.randomAlphanumeric(6);
 
     private final String EE_CHILD = "context-service";
 
@@ -84,7 +84,7 @@ public class ContextServicesTestCase extends EETestCaseAbstract {
 
     @Test
     public void addContextServiceInGUI() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "EEContextService_" + RandomStringUtils.randomAlphanumeric(6);
         ConfigFragment config = page.getConfigFragment();
         WizardWindow wizard = config.getResourceManager().addResource();
 

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/EETestCaseAbstract.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/EETestCaseAbstract.java
@@ -60,7 +60,7 @@ public class EETestCaseAbstract {
     }
 
     protected void editTextAndVerify(ResourceAddress address, String identifier, String attributeName) throws IOException, InterruptedException {
-        editTextAndVerify(address, identifier, attributeName, RandomStringUtils.randomAlphabetic(6));
+        editTextAndVerify(address, identifier, attributeName, "ee_" + attributeName + RandomStringUtils.randomAlphabetic(4));
     }
 
     protected void editCheckboxAndVerify(ResourceAddress address, String identifier, String attributeName, Boolean value) throws IOException, InterruptedException {

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/ExecutorTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/ExecutorTestCase.java
@@ -55,7 +55,7 @@ public class ExecutorTestCase extends EETestCaseAbstract {
     private final String NUMERIC_VALID = "7";
     private final String NUMERIC_INVALID = "7f";
     private final String JNDI_DEFAULT = "java:/";
-    private final String JNDI_VALID = JNDI_DEFAULT + RandomStringUtils.randomAlphanumeric(6);
+    private final String JNDI_VALID = JNDI_DEFAULT + "executorTestCase_" + RandomStringUtils.randomAlphanumeric(6);
     private final String REJECT_POLICY_VALID = "RETRY_ABORT";
 
     private final String EE_CHILD = "managed-executor-service";
@@ -160,7 +160,7 @@ public class ExecutorTestCase extends EETestCaseAbstract {
 
     @Test
     public void addExecutorInGUI() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "executor_" + RandomStringUtils.randomAlphanumeric(6);
         ConfigFragment config = page.getConfigFragment();
         WizardWindow wizard = config.getResourceManager().addResource();
 
@@ -185,7 +185,7 @@ public class ExecutorTestCase extends EETestCaseAbstract {
     }
 
     private String createExecutorService() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "executorGUI_" + RandomStringUtils.randomAlphanumeric(6);
         ResourceAddress address = new ResourceAddress(eeAddress).add(EE_CHILD, name);
         dispatcher.execute(new Operation.Builder("add", address)
                 .param(JNDI_NAME, JNDI_DEFAULT + name)

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/ScheduledExecutorTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/ScheduledExecutorTestCase.java
@@ -53,7 +53,7 @@ public class ScheduledExecutorTestCase extends EETestCaseAbstract {
     private final String NUMERIC_INVALID = "7f";
     private final String JNDI_INVALID = "test";
     private final String JNDI_DEFAULT = "java:/";
-    private final String JNDI_VALID = JNDI_DEFAULT + RandomStringUtils.randomAlphanumeric(6);
+    private final String JNDI_VALID = JNDI_DEFAULT + "ScheduledExecutor_" +  RandomStringUtils.randomAlphanumeric(6);
     private final String REJECT_POLICY_VALID = "RETRY_ABORT";
 
     private final String EE_CHILD = "managed-scheduled-executor-service";
@@ -144,7 +144,7 @@ public class ScheduledExecutorTestCase extends EETestCaseAbstract {
 
     @Test
     public void addExecutorInGUI() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "ScheduledExecutorGUI" + RandomStringUtils.randomAlphanumeric(6);
         ConfigFragment config = page.getConfigFragment();
         WizardWindow wizard = config.getResourceManager().addResource();
 
@@ -169,7 +169,7 @@ public class ScheduledExecutorTestCase extends EETestCaseAbstract {
     }
 
     private String createScheduledExecutorService() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "ScheduledExecutor" + RandomStringUtils.randomAlphanumeric(6);
         ResourceAddress address = new ResourceAddress(eeAddress).add(EE_CHILD, name);
         dispatcher.execute(new Operation.Builder("add", address)
                 .param(JNDI_NAME, JNDI_DEFAULT + name)

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/ThreadFactoryTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/ThreadFactoryTestCase.java
@@ -43,7 +43,7 @@ public class ThreadFactoryTestCase extends EETestCaseAbstract {
     private final String NUMERIC_INVALID = "7f";
     private final String JNDI_INVALID = "test";
     private final String JNDI_DEFAULT = "java:/";
-    private final String JNDI_VALID = JNDI_DEFAULT + RandomStringUtils.randomAlphanumeric(6);
+    private final String JNDI_VALID = JNDI_DEFAULT + "threadFactory" +  RandomStringUtils.randomAlphanumeric(6);
 
     private final String EE_CHILD = "managed-thread-factory";
 
@@ -93,7 +93,7 @@ public class ThreadFactoryTestCase extends EETestCaseAbstract {
 
     @Test
     public void addThreadFactoryInGUI() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "ThreadFactoryGUI" + RandomStringUtils.randomAlphanumeric(6);
         ConfigFragment config = page.getConfigFragment();
         WizardWindow wizard = config.getResourceManager().addResource();
 
@@ -118,7 +118,7 @@ public class ThreadFactoryTestCase extends EETestCaseAbstract {
     }
 
     private String createThreadFactory() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "ThreadFactory" + RandomStringUtils.randomAlphanumeric(6);
         ResourceAddress address = new ResourceAddress(eeAddress).add(EE_CHILD, name);
         dispatcher.execute(new Operation.Builder("add", address)
                 .param(JNDI_NAME, JNDI_DEFAULT + name)

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/CacheContainersTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/CacheContainersTestCase.java
@@ -97,13 +97,13 @@ public class CacheContainersTestCase {
     @Test
     public void editDefaultCache() {
         page.invokeContainerSettings(cacheContainerName);
-        attrChecker.editTextAndAssert(page, "default-cache", RandomStringUtils.randomAlphanumeric(5)).invoke();
+        attrChecker.editTextAndAssert(page, "default-cache", "infDefCache_" + RandomStringUtils.randomAlphanumeric(5)).invoke();
     }
 
     @Test
     public void editModule() {
         page.invokeContainerSettings(cacheContainerName);
-        attrChecker.editTextAndAssert(page, "module", RandomStringUtils.randomAlphanumeric(5)).invoke();
+        attrChecker.editTextAndAssert(page, "module", "infModule" + RandomStringUtils.randomAlphanumeric(5)).invoke();
     }
 
     @Test

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
@@ -92,7 +92,7 @@ public class JGroupAbstractTestCase {
 
     @Test(expected = AssertionError.class)
     public void socketBindingEditInvalid() {
-        String name = "invalidSocket_" + RandomStringUtils.randomAlphabetic(6);
+        String name = "JGroupsInvalidSocket_" + RandomStringUtils.randomAlphabetic(6);
         checker.editTextAndAssert(page, "socketBinding", name).dmrAttribute("socket-binding").invoke();
     }
 
@@ -112,7 +112,7 @@ public class JGroupAbstractTestCase {
 
     @Test
     public void machineEdit() {
-        String name = "machine_" + RandomStringUtils.randomAlphabetic(6);
+        String name = "JGroupsMachine_" + RandomStringUtils.randomAlphabetic(6);
         checker.editTextAndAssert(page, "machine", name).dmrAttribute("machine").invoke();
     }
 
@@ -123,13 +123,13 @@ public class JGroupAbstractTestCase {
 
     @Test
     public void siteEdit() {
-        String name = "site_" + RandomStringUtils.randomAlphabetic(6);
+        String name = "JGroupsSite_" + RandomStringUtils.randomAlphabetic(6);
         checker.editTextAndAssert(page, "site", name).invoke();
     }
 
     @Test
     public void rackEdit() {
-        String name = "rack_" + RandomStringUtils.randomAlphabetic(6);
+        String name = "JGroupsRack_" + RandomStringUtils.randomAlphabetic(6);
         checker.editTextAndAssert(page, "rack", name).invoke();
     }
 

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
@@ -92,7 +92,7 @@ public class JGroupAbstractTestCase {
 
     @Test(expected = AssertionError.class)
     public void socketBindingEditInvalid() {
-        String name = RandomStringUtils.randomAlphabetic(6);
+        String name = "invalidSocket_" + RandomStringUtils.randomAlphabetic(6);
         checker.editTextAndAssert(page, "socketBinding", name).dmrAttribute("socket-binding").invoke();
     }
 
@@ -112,7 +112,7 @@ public class JGroupAbstractTestCase {
 
     @Test
     public void machineEdit() {
-        String name = RandomStringUtils.randomAlphabetic(6);
+        String name = "machine_" + RandomStringUtils.randomAlphabetic(6);
         checker.editTextAndAssert(page, "machine", name).dmrAttribute("machine").invoke();
     }
 
@@ -123,13 +123,13 @@ public class JGroupAbstractTestCase {
 
     @Test
     public void siteEdit() {
-        String name = RandomStringUtils.randomAlphabetic(6);
+        String name = "site_" + RandomStringUtils.randomAlphabetic(6);
         checker.editTextAndAssert(page, "site", name).invoke();
     }
 
     @Test
     public void rackEdit() {
-        String name = RandomStringUtils.randomAlphabetic(6);
+        String name = "rack_" + RandomStringUtils.randomAlphabetic(6);
         checker.editTextAndAssert(page, "rack", name).invoke();
     }
 

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/security/SecurityDomainTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/security/SecurityDomainTestCase.java
@@ -38,7 +38,7 @@ public class SecurityDomainTestCase extends SecurityTestCaseAbstract {
     }
 
     private String createSecurityDomain() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "secDomain_" + RandomStringUtils.randomAlphanumeric(6);
         dispatcher.execute(new Operation.Builder("add", SECURITY_DOMAIN_TEMPLATE.resolve(context, name)).build());
         return name;
     }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/security/SecurityTestCaseAbstract.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/security/SecurityTestCaseAbstract.java
@@ -101,7 +101,7 @@ public abstract class SecurityTestCaseAbstract {
     }
 
     protected void editTextAndVerify(ResourceAddress address, String identifier, String attributeName) throws IOException, InterruptedException {
-        editTextAndVerify(address, identifier, attributeName, attributeName + RandomStringUtils.randomAlphabetic(4));
+        editTextAndVerify(address, identifier, attributeName, "sec_" + attributeName + RandomStringUtils.randomAlphabetic(4));
     }
 
     protected void editCheckboxAndVerify(ResourceAddress address, String identifier, String attributeName, Boolean value) throws IOException, InterruptedException {

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/security/SecurityTestCaseAbstract.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/security/SecurityTestCaseAbstract.java
@@ -101,7 +101,7 @@ public abstract class SecurityTestCaseAbstract {
     }
 
     protected void editTextAndVerify(ResourceAddress address, String identifier, String attributeName) throws IOException, InterruptedException {
-        editTextAndVerify(address, identifier, attributeName, RandomStringUtils.randomAlphabetic(6));
+        editTextAndVerify(address, identifier, attributeName, attributeName + RandomStringUtils.randomAlphabetic(4));
     }
 
     protected void editCheckboxAndVerify(ResourceAddress address, String identifier, String attributeName, Boolean value) throws IOException, InterruptedException {

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/transactions/TransactionsOperations.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/transactions/TransactionsOperations.java
@@ -33,7 +33,7 @@ public class TransactionsOperations {
     }
 
     public String createSocketBinding() {
-        String name = "sb_" + RandomStringUtils.randomAlphanumeric(6);
+        String name = "TransactionsOpsSB_" + RandomStringUtils.randomAlphanumeric(6);
         ResourceAddress address = socketBindingAddressTemplate.resolve(context, name);
         Map<String, String> params = ImmutableMap.of("port", String.valueOf(ThreadLocalRandom.current().nextInt(1000, 9999)));
         executeAddAction(address, params);

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/transactions/TransactionsTestCaseAbstract.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/transactions/TransactionsTestCaseAbstract.java
@@ -51,7 +51,7 @@ public abstract class TransactionsTestCaseAbstract {
     }
 
     protected void editTextAndVerify(ResourceAddress address, String identifier, String attributeName) throws IOException, InterruptedException {
-        editTextAndVerify(address, identifier, attributeName, "transactions" + RandomStringUtils.randomAlphabetic(6));
+        editTextAndVerify(address, identifier, attributeName, "transactions" + attributeName + RandomStringUtils.randomAlphabetic(6));
     }
 
     protected void editCheckboxAndVerify(ResourceAddress address, String identifier, String attributeName, Boolean value) throws IOException, InterruptedException {

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/transactions/TransactionsTestCaseAbstract.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/transactions/TransactionsTestCaseAbstract.java
@@ -51,7 +51,7 @@ public abstract class TransactionsTestCaseAbstract {
     }
 
     protected void editTextAndVerify(ResourceAddress address, String identifier, String attributeName) throws IOException, InterruptedException {
-        editTextAndVerify(address, identifier, attributeName, RandomStringUtils.randomAlphabetic(6));
+        editTextAndVerify(address, identifier, attributeName, "transactions" + RandomStringUtils.randomAlphabetic(6));
     }
 
     protected void editCheckboxAndVerify(ResourceAddress address, String identifier, String attributeName, Boolean value) throws IOException, InterruptedException {

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/AJPListenerTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/AJPListenerTestCase.java
@@ -391,7 +391,7 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
 
     @Test
     public void addAJPListenerInGUI() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "ajpGUI_" + RandomStringUtils.randomAlphanumeric(6);
         String socketBinding = operations.createSocketBinding();
         ConfigFragment config = page.getConfigFragment();
         WizardWindow wizard = config.getResourceManager().addResource();

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/HTTPListenerTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/HTTPListenerTestCase.java
@@ -416,7 +416,7 @@ public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
 
     @Test
     public void addHTTPListenerInGUI() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "httpListener_" + RandomStringUtils.randomAlphanumeric(6);
         ConfigFragment config = page.getConfigFragment();
         WizardWindow wizard = config.getResourceManager().addResource();
 

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/HTTPSListenerTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/HTTPSListenerTestCase.java
@@ -449,7 +449,7 @@ public class HTTPSListenerTestCase extends UndertowTestCaseAbstract {
 
     @Test
     public void addHTTPSListenerInGUI() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "HTTPSListener_" + RandomStringUtils.randomAlphanumeric(6);
         String socketBinding = operations.createSocketBinding();
         ConfigFragment config = page.getConfigFragment();
         WizardWindow wizard = config.getResourceManager().addResource();

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/HostTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/HostTestCase.java
@@ -98,8 +98,8 @@ public class HostTestCase extends UndertowTestCaseAbstract {
 
     @Test
     public void addHTTPServerHostInGUI() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
-        String webModule = RandomStringUtils.randomAlphanumeric(6);
+        String name = "httpServer_" + RandomStringUtils.randomAlphanumeric(6);
+        String webModule = "webModule_" + RandomStringUtils.randomAlphanumeric(6);
         ConfigFragment config = page.getConfigFragment();
         WizardWindow wizard = config.getResourceManager().addResource();
 

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowOperations.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowOperations.java
@@ -66,6 +66,7 @@ public class UndertowOperations {
 
     public String createAJPListener(String httpServer) {
         String name = RandomStringUtils.randomAlphanumeric(6);
+        log.info("Creating AJP listener " + name);
         Map<String, String> params = ImmutableMap.of("socket-binding", createSocketBinding());
         executeAddAction(ajpListenerTemplate.resolve(context, httpServer, name), params);
         return name;
@@ -168,7 +169,7 @@ public class UndertowOperations {
     }
 
     public String createWorker() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "worker_" + RandomStringUtils.randomAlphanumeric(6);
         ResourceAddress address = ioWorkerAddressTemplate.resolve(context, name);
         executeAddAction(address);
         return name;
@@ -180,7 +181,7 @@ public class UndertowOperations {
     }
 
     public String createBufferPool() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "bufferPool_" + RandomStringUtils.randomAlphanumeric(6);
         ResourceAddress address = ioBufferPoolAddressTemplate.resolve(context, name);
         executeAddAction(address);
         return name;
@@ -192,7 +193,7 @@ public class UndertowOperations {
     }
 
     public String createSocketBinding() {
-        String name = RandomStringUtils.randomAlphanumeric(6);
+        String name = "socketBinding_" + RandomStringUtils.randomAlphanumeric(6);
         ResourceAddress address = socketBindingAddressTemplate.resolve(context, name);
         Map<String, String> params = ImmutableMap.of("port", String.valueOf(ThreadLocalRandom.current().nextInt(1000, 9999)));
         executeAddAction(address, params);

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowOperations.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowOperations.java
@@ -169,7 +169,7 @@ public class UndertowOperations {
     }
 
     public String createWorker() {
-        String name = "worker_" + RandomStringUtils.randomAlphanumeric(6);
+        String name = "UndertowWorker_" + RandomStringUtils.randomAlphanumeric(6);
         ResourceAddress address = ioWorkerAddressTemplate.resolve(context, name);
         executeAddAction(address);
         return name;
@@ -181,7 +181,7 @@ public class UndertowOperations {
     }
 
     public String createBufferPool() {
-        String name = "bufferPool_" + RandomStringUtils.randomAlphanumeric(6);
+        String name = "UndertowBufferPool_" + RandomStringUtils.randomAlphanumeric(6);
         ResourceAddress address = ioBufferPoolAddressTemplate.resolve(context, name);
         executeAddAction(address);
         return name;
@@ -193,7 +193,7 @@ public class UndertowOperations {
     }
 
     public String createSocketBinding() {
-        String name = "socketBinding_" + RandomStringUtils.randomAlphanumeric(6);
+        String name = "UndertowSocketBinding_" + RandomStringUtils.randomAlphanumeric(6);
         ResourceAddress address = socketBindingAddressTemplate.resolve(context, name);
         Map<String, String> params = ImmutableMap.of("port", String.valueOf(ThreadLocalRandom.current().nextInt(1000, 9999)));
         executeAddAction(address, params);

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowTestCaseAbstract.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowTestCaseAbstract.java
@@ -71,7 +71,7 @@ public abstract class UndertowTestCaseAbstract {
     }
 
     protected void editTextAndVerify(ResourceAddress address, String identifier, String attributeName) throws IOException, InterruptedException {
-        editTextAndVerify(address, identifier, attributeName, RandomStringUtils.randomAlphabetic(6));
+        editTextAndVerify(address, identifier, attributeName, attributeName + RandomStringUtils.randomAlphabetic(4));
     }
 
     protected void editCheckboxAndVerify(ResourceAddress address, String identifier, String attributeName, Boolean value) throws IOException, InterruptedException {

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowTestCaseAbstract.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowTestCaseAbstract.java
@@ -71,7 +71,7 @@ public abstract class UndertowTestCaseAbstract {
     }
 
     protected void editTextAndVerify(ResourceAddress address, String identifier, String attributeName) throws IOException, InterruptedException {
-        editTextAndVerify(address, identifier, attributeName, attributeName + RandomStringUtils.randomAlphabetic(4));
+        editTextAndVerify(address, identifier, attributeName, "undertow_" + attributeName + RandomStringUtils.randomAlphabetic(4));
     }
 
     protected void editCheckboxAndVerify(ResourceAddress address, String identifier, String attributeName, Boolean value) throws IOException, InterruptedException {

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/server/ServerOperationsTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/server/ServerOperationsTestCase.java
@@ -92,7 +92,7 @@ public class ServerOperationsTestCase {
 
     @Test
     public void addServer() {
-        String serverName = "srv_" + RandomStringUtils.randomAlphanumeric(8);
+        String serverName = "ServerOperationsSrv_" + RandomStringUtils.randomAlphanumeric(8);
 
         try {
             navigationByServerGroup.addAddress(FinderNames.SERVER).selectColumn().invoke("Add");
@@ -114,7 +114,7 @@ public class ServerOperationsTestCase {
 
     @Test
     public void removeServer() {
-        String serverName = "srv_" + RandomStringUtils.randomAlphanumeric(8);
+        String serverName = "ServerOperationsSrv_" + RandomStringUtils.randomAlphanumeric(8);
         cli.executeCommand(CliUtils.buildCommand("/host=master/server-config=" + serverName, ":add",
                 new String[]{"group=main-server-group", "socket-binding-port-offset=999"}));
 

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/server/ServerOperationsTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/server/ServerOperationsTestCase.java
@@ -92,7 +92,7 @@ public class ServerOperationsTestCase {
 
     @Test
     public void addServer() {
-        String serverName = RandomStringUtils.randomAlphanumeric(8);
+        String serverName = "srv_" + RandomStringUtils.randomAlphanumeric(8);
 
         try {
             navigationByServerGroup.addAddress(FinderNames.SERVER).selectColumn().invoke("Add");
@@ -114,7 +114,7 @@ public class ServerOperationsTestCase {
 
     @Test
     public void removeServer() {
-        String serverName = RandomStringUtils.randomAlphanumeric(8);
+        String serverName = "srv_" + RandomStringUtils.randomAlphanumeric(8);
         cli.executeCommand(CliUtils.buildCommand("/host=master/server-config=" + serverName, ":add",
                 new String[]{"group=main-server-group", "socket-binding-port-offset=999"}));
 


### PR DESCRIPTION
All randomly generated strings should have assigned "id" which helps in stabilization debugging. If you find any randomly generated string without "identifier", please report.
