### PR TITLE
Stabilizating messaging tests

### DIFF
--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/clustering/BroadcastGroupsTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/clustering/BroadcastGroupsTestCase.java
@@ -45,16 +45,12 @@ public class BroadcastGroupsTestCase extends AbstractMessagingTestCase {
     @BeforeClass
     public static void setUp() throws Exception {
         operations.add(NEW_SERVER);
-        administration.reloadIfRequired();
         new ResourceVerifier(NEW_SERVER, client).verifyExists();
-        operations.add(CONNECTOR_ADDRESS, Values.of("factory-class", "foo"));
-        administration.reloadIfRequired();
+        operations.add(CONNECTOR_ADDRESS, Values.of("factory-class", "org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory"));
         new ResourceVerifier(CONNECTOR_ADDRESS, client).verifyExists();
         operations.add(BG_ADDRESS);
-        administration.reloadIfRequired();
         new ResourceVerifier(BG_ADDRESS, client).verifyExists();
         operations.add(BG_TBR_ADDRESS);
-        administration.reloadIfRequired();
         new ResourceVerifier(BG_TBR_ADDRESS, client).verifyExists();
         administration.reloadIfRequired();
     }
@@ -101,8 +97,7 @@ public class BroadcastGroupsTestCase extends AbstractMessagingTestCase {
 
     @Test
     public void removeBroadcastGroup() throws Exception {
-        page.selectInTable(BG_TBR_NAME, 0);
-        page.remove();
+        page.remove(BG_TBR_NAME);
 
         new ResourceVerifier(BG_TBR_ADDRESS, client).verifyDoesNotExist();
     }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/connections/BridgesTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/connections/BridgesTestCase.java
@@ -5,11 +5,11 @@ import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.hal.testsuite.category.Shared;
 import org.jboss.hal.testsuite.creaper.ResourceVerifier;
-import org.jboss.hal.testsuite.creaper.command.BackupAndRestoreAttributes;
 import org.jboss.hal.testsuite.fragment.ConfigFragment;
 import org.jboss.hal.testsuite.fragment.formeditor.Editor;
 import org.jboss.hal.testsuite.page.config.MessagingPage;
 import org.jboss.hal.testsuite.test.configuration.messaging.AbstractMessagingTestCase;
+import org.jboss.hal.testsuite.util.ConfigChecker;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -26,7 +26,7 @@ import org.wildfly.extras.creaper.core.online.operations.OperationException;
 import org.wildfly.extras.creaper.core.online.operations.Values;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
@@ -43,18 +43,21 @@ public class BridgesTestCase extends AbstractMessagingTestCase {
     private static final Address BRIDGE_TBA_ADDRESS = DEFAULT_MESSAGING_SERVER.and("bridge", BRIDGE_TBA);
 
     private static final String CONNECTOR = "http-connector";
-    private static final String QUEUE = "testQueue_" + RandomStringUtils.randomAlphanumeric(5);
-    private static final String QUEUE_EDIT = "testQueue_" + RandomStringUtils.randomAlphanumeric(5);
+    private static final String QUEUE_CREATE_BRIDGE = "testQueue_" + RandomStringUtils.randomAlphanumeric(5);
+    private static final String QUEUE_EDIT_BRIDGE = "testQueue_" + RandomStringUtils.randomAlphanumeric(5);
     private static final String DISCOVERY_GROUP_EDIT = "discoveryGroupBridges_" + RandomStringUtils.randomAlphanumeric(5);
 
     @BeforeClass
     public static void setUp() throws Exception {
-        List<String> jndiEntries = Arrays.asList(QUEUE);
-        client.apply(new AddQueue.Builder(QUEUE).jndiEntries(jndiEntries).build());
-        client.apply(new AddQueue.Builder(QUEUE_EDIT).jndiEntries(jndiEntries).build());
+        //add queues
+        List<String> entriesQueueCreateBridge = Collections.singletonList(QUEUE_CREATE_BRIDGE);
+        List<String> entriesQueueEditBridge = Collections.singletonList(QUEUE_EDIT_BRIDGE);
+        client.apply(new AddQueue.Builder(QUEUE_CREATE_BRIDGE).jndiEntries(entriesQueueCreateBridge).build());
+        client.apply(new AddQueue.Builder(QUEUE_EDIT_BRIDGE).jndiEntries(entriesQueueEditBridge).build());
+        //add bridges
         createBridge(BRIDGE_ADDRESS);
         createBridge(BRIDGE_TBR_ADDRESS);
-        operations.add(DEFAULT_MESSAGING_SERVER.and("discovery-group", DISCOVERY_GROUP_EDIT));
+
         administration.reloadIfRequired();
     }
 
@@ -74,18 +77,21 @@ public class BridgesTestCase extends AbstractMessagingTestCase {
     }
 
     @AfterClass
-    public static void afterClass() throws IOException, OperationException, CommandFailedException {
+    public static void afterClass() throws IOException, OperationException, CommandFailedException, TimeoutException, InterruptedException {
+        //remove bridges
         operations.removeIfExists(BRIDGE_ADDRESS);
         operations.removeIfExists(BRIDGE_TBA_ADDRESS);
         operations.removeIfExists(BRIDGE_TBR_ADDRESS);
-        client.apply(new RemoveQueue(QUEUE));
-        client.apply(new RemoveQueue(QUEUE_EDIT));
-        operations.remove(DEFAULT_MESSAGING_SERVER.and("discovery-group", DISCOVERY_GROUP_EDIT));
+        //remove queues
+        client.apply(new RemoveQueue(QUEUE_CREATE_BRIDGE));
+        client.apply(new RemoveQueue(QUEUE_EDIT_BRIDGE));
+
+        administration.reloadIfRequired();
     }
 
     @Test
     public void addBridge() throws Exception {
-        page.addBridge(BRIDGE_TBA, QUEUE, "testAddress", CONNECTOR);
+        page.addBridge(BRIDGE_TBA, QUEUE_CREATE_BRIDGE, "testAddress", CONNECTOR);
         new ResourceVerifier(BRIDGE_TBA_ADDRESS, client).verifyExists();
     }
 
@@ -96,7 +102,7 @@ public class BridgesTestCase extends AbstractMessagingTestCase {
 
     @Test
     public void updateBridgeQueue() throws Exception {
-        editTextAndVerify(BRIDGE_ADDRESS, "queueName", "queue-name", QUEUE_EDIT);
+        editTextAndVerify(BRIDGE_ADDRESS, "queueName", "queue-name", QUEUE_EDIT_BRIDGE);
     }
 
     @Test
@@ -106,30 +112,33 @@ public class BridgesTestCase extends AbstractMessagingTestCase {
 
     @Test
     public void updateBridgeTransformerClass() throws Exception {
-        BackupAndRestoreAttributes backup = new BackupAndRestoreAttributes.Builder(BRIDGE_ADDRESS)
-                .excluded("discovery-group")
-                .build();
         try {
-            client.apply(backup.backup());
-            editTextAndVerify(BRIDGE_ADDRESS, "transformerClass", "transformer-class-name",
-                    "org.apache.activemq.artemis.jms.example.HatColourChangeTransformer");
+            new ConfigChecker.Builder(client, BRIDGE_ADDRESS)
+                    .configFragment(page.getConfigFragment())
+                    .editAndSave(ConfigChecker.InputType.TEXT, "transformerClass", "clazz")
+                    .verifyFormSaved()
+                    .verifyAttribute("transformer-class-name", "clazz");
         } finally {
-            client.apply(backup.restore());
+            operations.undefineAttribute(BRIDGE_ADDRESS, "transformer-class-name");
         }
 
     }
 
     @Test
     public void updateBridgeDiscoveryGroup() throws Exception {
-        ConfigFragment editPanelFragment = page.getConfigFragment();
-        Editor editor = editPanelFragment.edit();
+        try {
+            ConfigFragment editPanelFragment = page.getConfigFragment();
+            Editor editor = editPanelFragment.edit();
 
-        editor.text("staticConnectors", "");
-        editor.text("discoveryGroup", DISCOVERY_GROUP_EDIT);
-        boolean finished = editPanelFragment.save();
+            editor.text("staticConnectors", "");
+            editor.text("discoveryGroup", DISCOVERY_GROUP_EDIT);
+            boolean finished = editPanelFragment.save();
 
-        Assert.assertTrue("Config should be saved and closed.", finished);
-        new ResourceVerifier(BRIDGE_ADDRESS, client).verifyAttribute("discovery-group", DISCOVERY_GROUP_EDIT);
+            Assert.assertTrue("Config should be saved and closed.", finished);
+            new ResourceVerifier(BRIDGE_ADDRESS, client).verifyAttribute("discovery-group", DISCOVERY_GROUP_EDIT);
+        } finally {
+            operations.undefineAttribute(BRIDGE_ADDRESS, "discovery-group");
+        }
     }
 
     @Test
@@ -165,7 +174,7 @@ public class BridgesTestCase extends AbstractMessagingTestCase {
     private static void createBridge(Address address) throws Exception {
         operations.add(address, Values.empty()
                 .andList("static-connectors", CONNECTOR)
-                .and("queue-name", QUEUE));
+                .and("queue-name", QUEUE_CREATE_BRIDGE));
         new ResourceVerifier(address, client).verifyExists();
     }
 

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/connections/GenericAcceptorTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/connections/GenericAcceptorTestCase.java
@@ -8,6 +8,7 @@ import org.jboss.hal.testsuite.creaper.ResourceVerifier;
 import org.jboss.hal.testsuite.creaper.command.messaging.AddMessagingAcceptor;
 import org.jboss.hal.testsuite.page.config.MessagingPage;
 import org.jboss.hal.testsuite.test.configuration.messaging.AbstractMessagingTestCase;
+import org.jboss.hal.testsuite.util.ConfigChecker;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -95,8 +96,15 @@ public class GenericAcceptorTestCase extends AbstractMessagingTestCase {
 
     @Test
     public void editFactoryClass() throws Exception {
-        editTextAndVerify(GENERIC_ACCEPTOR_ADDRESS, "factoryClass", "factory-class", "fc");
-        editTextAndVerify(GENERIC_ACCEPTOR_ADDRESS, "factoryClass", "factory-class", FACTORY_CLASS);
+        try {
+            new ConfigChecker.Builder(client, GENERIC_ACCEPTOR_ADDRESS)
+                    .configFragment(page.getConfigFragment())
+                    .editAndSave(ConfigChecker.InputType.TEXT, "factoryClass", "fc")
+                    .verifyFormSaved()
+                    .verifyAttribute("factory-class", "fc");
+        } finally {
+            operations.writeAttribute(GENERIC_ACCEPTOR_ADDRESS, "factory-class", FACTORY_CLASS);
+        }
     }
 
     @Test

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/connections/GenericConnectorTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/connections/GenericConnectorTestCase.java
@@ -8,6 +8,7 @@ import org.jboss.hal.testsuite.creaper.ResourceVerifier;
 import org.jboss.hal.testsuite.creaper.command.messaging.AddMessagingConnector;
 import org.jboss.hal.testsuite.page.config.MessagingPage;
 import org.jboss.hal.testsuite.test.configuration.messaging.AbstractMessagingTestCase;
+import org.jboss.hal.testsuite.util.ConfigChecker;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -91,8 +92,15 @@ public class GenericConnectorTestCase extends AbstractMessagingTestCase {
 
     @Test
     public void editFactoryClass() throws Exception {
-        editTextAndVerify(GENERIC_CONNECTOR_ADDRESS, "factoryClass", "factory-class", "fc");
-        editTextAndVerify(GENERIC_CONNECTOR_ADDRESS, "factoryClass", "factory-class", FACTORY_CLASS);
+        try {
+            new ConfigChecker.Builder(client, GENERIC_CONNECTOR_ADDRESS)
+                    .configFragment(page.getConfigFragment())
+                    .editAndSave(ConfigChecker.InputType.TEXT, "factoryClass", "fc")
+                    .verifyFormSaved()
+                    .verifyAttribute("factory-class", "fc");
+        } finally {
+            operations.writeAttribute(GENERIC_CONNECTOR_ADDRESS, "factory-class", FACTORY_CLASS);
+        }
     }
 
     @Test

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/providerSettings/JournalTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/providerSettings/JournalTestCase.java
@@ -99,11 +99,11 @@ public class JournalTestCase extends AbstractMessagingTestCase {
 
     @Test
     public void updateJournalCompactPercentage() throws Exception {
-        editTextAndVerify(SERVER_ADDRESS, "journal-compact-percentage", 110);
+        editTextAndVerify(SERVER_ADDRESS, "journal-compact-percentage", 99);
     }
 
     @Test
     public void updateJournalFileSize() throws Exception {
-        editTextAndVerify(SERVER_ADDRESS, "journal-file-size", 110L);
+        editTextAndVerify(SERVER_ADDRESS, "journal-file-size", 4296L);
     }
 }


### PR DESCRIPTION
Trying to improve stability of messaging tests. Replaced filling classes names with existing one where possible, fixed names, replace invalid attributes with valid, better cleanup...
