### PR TITLE
Trying to stabilize undertow tests, added Creaper

### DIFF
--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/AJPListenerTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/AJPListenerTestCase.java
@@ -4,8 +4,7 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.hal.testsuite.category.Shared;
-import org.jboss.hal.testsuite.dmr.AddressTemplate;
-import org.jboss.hal.testsuite.dmr.ResourceAddress;
+import org.jboss.hal.testsuite.creaper.ResourceVerifier;
 import org.jboss.hal.testsuite.fragment.ConfigFragment;
 import org.jboss.hal.testsuite.fragment.formeditor.Editor;
 import org.jboss.hal.testsuite.fragment.shared.modal.WizardWindow;
@@ -17,15 +16,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.commands.undertow.AddUndertowListener;
 import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
-/**
- * @author Jan Kasik <jkasik@redhat.com>
- *         Created on 15.9.15.
- */
 @RunWith(Arquillian.class)
 @Category(Shared.class)
 public class AJPListenerTestCase extends UndertowTestCaseAbstract {
@@ -34,166 +32,157 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     private UndertowHTTPPage page;
 
     //identifiers
-    private final String ALLOW_ENCODED_SLASH = "allow-encoded-slash";
-    private final String ALLOW_EQUALS_IN_COOKIE_VALUE = "allow-equals-in-cookie-value";
-    private final String ALWAYS_SET_KEEP_ALIVE = "always-set-keep-alive";
-    private final String BUFFER_PIPELINED_DATA = "buffer-pipelined-data";
-    private final String BUFFER_POOL = "buffer-pool";
-    private final String DECODE_URL = "decode-url";
-    private final String ENABLED = "enabled";
-    private final String MAX_BUFFERED_REQUEST_SIZE = "max-buffered-request-size";
-    private final String MAX_CONNECTIONS = "max-connections";
-    private final String MAX_COOKIES = "max-cookies";
-    private final String MAX_HEADER_SIZE = "max-header-size";
-    private final String MAX_HEADERS = "max-headers";
-    private final String MAX_PARAMETERS = "max-parameters";
-    private final String MAX_POST_SIZE = "max-post-size";
-    private final String NO_REQUEST_TIMEOUT = "no-request-timeout";
-    private final String READ_TIMEOUT = "read-timeout";
-    private final String RECEIVE_BUFFER = "receive-buffer";
-    private final String RECORD_REQUEST_START_TIME = "record-request-start-time";
-    private final String REDIRECT_SOCKET = "redirect-socket";
-    private final String REQUEST_PARSE_TIMEOUT = "request-parse-timeout";
-    private final String RESOLVE_PEER_ADDRESS = "resolve-peer-address";
-    private final String SCHEME = "scheme";
-    private final String SEND_BUFFER = "send-buffer";
-    private final String SOCKET_BINDING = "socket-binding";
-    private final String TCP_BACKLOG = "tcp-backlog";
-    private final String TCP_KEEP_ALIVE = "tcp-keep-alive";
-    private final String URL_CHARSET = "url-charset";
-    private final String WORKER = "worker";
-    private final String WRITE_TIMEOUT = "write-timeout";
-
-    //attribute names
-    private final String ALLOW_ENCODED_SLASH_ATTR = "allow-encoded-slash";
-    private final String ALLOW_EQUALS_IN_COOKIE_VALUE_ATTR = "allow-equals-in-cookie-value";
-    private final String ALWAYS_SET_KEEP_ALIVE_ATTR = "always-set-keep-alive";
-    private final String BUFFER_PIPELINED_DATA_ATTR = "buffer-pipelined-data";
-    private final String BUFFER_POOL_ATTR = "buffer-pool";
-    private final String DECODE_URL_ATTR = "decode-url";
-    private final String ENABLED_ATTR = "enabled";
-    private final String MAX_BUFFERED_REQUEST_SIZE_ATTR = "max-buffered-request-size";
-    private final String MAX_CONNECTIONS_ATTR = "max-connections";
-    private final String MAX_COOKIES_ATTR = "max-cookies";
-    private final String MAX_HEADER_SIZE_ATTR = "max-header-size";
-    private final String MAX_HEADERS_ATTR = "max-headers";
-    private final String MAX_PARAMETERS_ATTR = "max-parameters";
-    private final String MAX_POST_SIZE_ATTR = "max-post-size";
-    private final String NO_REQUEST_TIMEOUT_ATTR = "no-request-timeout";
-    private final String READ_TIMEOUT_ATTR = "read-timeout";
-    private final String RECEIVE_BUFFER_ATTR = "receive-buffer";
-    private final String RECORD_REQUEST_START_TIME_ATTR = "record-request-start-time";
-    private final String REDIRECT_SOCKET_ATTR = "redirect-socket";
-    private final String REQUEST_PARSE_TIMEOUT_ATTR = "request-parse-timeout";
-    private final String RESOLVE_PEER_ADDRESS_ATTR = "resolve-peer-address";
-    private final String SCHEME_ATTR = "scheme";
-    private final String SEND_BUFFER_ATTR = "send-buffer";
-    private final String SOCKET_BINDING_ATTR = "socket-binding";
-    private final String TCP_BACKLOG_ATTR = "tcp-backlog";
-    private final String TCP_KEEP_ALIVE_ATTR = "tcp-keep-alive";
-    private final String URL_CHARSET_ATTR = "url-charset";
-    private final String WORKER_ATTR = "worker";
-    private final String WRITE_TIMEOUT_ATTR = "write-timeout";
+    private static final String ALLOW_ENCODED_SLASH = "allow-encoded-slash";
+    private static final String ALLOW_EQUALS_IN_COOKIE_VALUE = "allow-equals-in-cookie-value";
+    private static final String ALWAYS_SET_KEEP_ALIVE = "always-set-keep-alive";
+    private static final String BUFFER_PIPELINED_DATA = "buffer-pipelined-data";
+    private static final String BUFFER_POOL = "buffer-pool";
+    private static final String DECODE_URL = "decode-url";
+    private static final String ENABLED = "enabled";
+    private static final String MAX_BUFFERED_REQUEST_SIZE = "max-buffered-request-size";
+    private static final String MAX_CONNECTIONS = "max-connections";
+    private static final String MAX_COOKIES = "max-cookies";
+    private static final String MAX_HEADER_SIZE = "max-header-size";
+    private static final String MAX_HEADERS = "max-headers";
+    private static final String MAX_PARAMETERS = "max-parameters";
+    private static final String MAX_POST_SIZE = "max-post-size";
+    private static final String NO_REQUEST_TIMEOUT = "no-request-timeout";
+    private static final String READ_TIMEOUT = "read-timeout";
+    private static final String RECEIVE_BUFFER = "receive-buffer";
+    private static final String RECORD_REQUEST_START_TIME = "record-request-start-time";
+    private static final String REDIRECT_SOCKET = "redirect-socket";
+    private static final String REQUEST_PARSE_TIMEOUT = "request-parse-timeout";
+    private static final String RESOLVE_PEER_ADDRESS = "resolve-peer-address";
+    private static final String SCHEME = "scheme";
+    private static final String SEND_BUFFER = "send-buffer";
+    private static final String SOCKET_BINDING = "socket-binding";
+    private static final String TCP_BACKLOG = "tcp-backlog";
+    private static final String TCP_KEEP_ALIVE = "tcp-keep-alive";
+    private static final String URL_CHARSET = "url-charset";
+    private static final String WORKER = "worker";
+    private static final String WRITE_TIMEOUT = "write-timeout";
 
     //values
-    private final String NUMERIC_VALID = "25";
-    private final String NUMERIC_INVALID = "25fazf";
+    private static final String HTTP_SERVER = "undertow-http-server-ajp_" + RandomStringUtils.randomAlphanumeric(5);
 
-    private static AddressTemplate ajpListenerTemplate = httpServerTemplate.append("/ajp-listener=*");
-    private static String httpServer;
-    private static String ajpListener;
-    private static String ajpListenerToBeRemoved;
-    private static ResourceAddress address;
+    private static final String AJP_LISTENER = "ajp-listener_" + RandomStringUtils.randomAlphanumeric(5);
+    private static final String AJP_LISTENER_TBR = "ajp-listener-tbr_" + RandomStringUtils.randomAlphanumeric(5);
+    private static final String AJP_LISTENER_TBA = "ajp-listener-tba_" + RandomStringUtils.randomAlphanumeric(5);
+
+    private static final Address HTTP_SERVER_ADDRESS = UNDERTOW_ADDRESS.and("server", HTTP_SERVER);
+
+    private static final Address AJP_LISTENER_ADDRESS = HTTP_SERVER_ADDRESS.and("ajp-listener", AJP_LISTENER);
+    private static final Address AJP_LISTENER_ADDRESS_TBR = HTTP_SERVER_ADDRESS.and("ajp-listener", AJP_LISTENER_TBR);
+    private static final Address AJP_LISTENER_ADDRESS_TBA = HTTP_SERVER_ADDRESS.and("ajp-listener", AJP_LISTENER_TBA);
 
     @BeforeClass
-    public static void setUp() throws IOException, CommandFailedException, TimeoutException, InterruptedException {
-        httpServer = operations.createHTTPServer();
-        ajpListener = operations.createAJPListener(httpServer);
-        ajpListenerToBeRemoved = operations.createAJPListener(httpServer);
-        address = ajpListenerTemplate.resolve(context, httpServer, ajpListener);
+    public static void setUp() throws Exception {
+        //add http server
+        operations.add(HTTP_SERVER_ADDRESS);
+        administration.reloadIfRequired();
+        //add ajp listeners which will be used
+        client.apply(new AddUndertowListener.AjpBuilder(AJP_LISTENER, HTTP_SERVER,
+                        undertowOps.createSocketBindingWithoutReference())
+                .enabled(true)
+                .build());
+        client.apply(new AddUndertowListener.AjpBuilder(AJP_LISTENER_TBR, HTTP_SERVER,
+                        undertowOps.createSocketBindingWithoutReference())
+                .enabled(true)
+                .build());
+
+        administration.reloadIfRequired();
     }
 
     @Before
     public void before() {
-        navigate2ajpListener();
+        page.navigate();
+        page.viewHTTPServer(HTTP_SERVER)
+                .switchToAJPListeners()
+                .selectItemInTableByText(AJP_LISTENER);
     }
 
     @AfterClass
-    public static void tearDown() throws InterruptedException, CommandFailedException, TimeoutException, IOException {
-        operations.removeAJPListener(httpServer, ajpListener);
-        operations.removeHTTPServer(httpServer);
+    public static void tearDown() throws InterruptedException, CommandFailedException, TimeoutException, IOException, OperationException {
+        operations.removeIfExists(AJP_LISTENER_ADDRESS);
+        operations.removeIfExists(AJP_LISTENER_ADDRESS_TBA);
+        operations.removeIfExists(AJP_LISTENER_ADDRESS_TBR);
+        //remove used http server
+        operations.removeIfExists(HTTP_SERVER_ADDRESS);
+        //servers should not be in reload or restart required after test case ends
+        administration.restartIfRequired();
+        administration.reloadIfRequired();
     }
 
     @Test
-    public void setAllowEncodedSlashToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALLOW_ENCODED_SLASH, ALLOW_ENCODED_SLASH_ATTR, true);
+    public void setAllowEncodedSlashToTrue() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, ALLOW_ENCODED_SLASH, true);
     }
 
     @Test
-    public void setAllowEncodedSlashToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALLOW_ENCODED_SLASH, ALLOW_ENCODED_SLASH_ATTR, false);
+    public void setAllowEncodedSlashToFalse() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, ALLOW_ENCODED_SLASH, false);
     }
 
     @Test
-    public void setAllowEqualsInCookieValueToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALLOW_EQUALS_IN_COOKIE_VALUE, ALLOW_EQUALS_IN_COOKIE_VALUE_ATTR, true);
+    public void setAllowEqualsInCookieValueToTrue() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, ALLOW_EQUALS_IN_COOKIE_VALUE, true);
     }
 
     @Test
-    public void setAllowEqualsInCookieValueToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALLOW_EQUALS_IN_COOKIE_VALUE, ALLOW_EQUALS_IN_COOKIE_VALUE_ATTR, false);
+    public void setAllowEqualsInCookieValueToFalse() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, ALLOW_EQUALS_IN_COOKIE_VALUE, false);
     }
 
     @Test
-    public void setAlwaysSetKeepAliveToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALWAYS_SET_KEEP_ALIVE, ALWAYS_SET_KEEP_ALIVE_ATTR, true);
+    public void setAlwaysSetKeepAliveToTrue() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, ALWAYS_SET_KEEP_ALIVE, true);
     }
 
     @Test
-    public void setAlwaysSetKeepAliveToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALWAYS_SET_KEEP_ALIVE, ALWAYS_SET_KEEP_ALIVE_ATTR, false);
+    public void setAlwaysSetKeepAliveToFalse() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, ALWAYS_SET_KEEP_ALIVE, false);
     }
 
     @Test
-    public void setBufferPipelinedDataToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, BUFFER_PIPELINED_DATA, BUFFER_PIPELINED_DATA_ATTR, true);
+    public void setBufferPipelinedDataToTrue() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, BUFFER_PIPELINED_DATA, true);
     }
 
     @Test
-    public void setBufferPipelinedDataToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, BUFFER_PIPELINED_DATA, BUFFER_PIPELINED_DATA_ATTR, false);
+    public void setBufferPipelinedDataToFalse() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, BUFFER_PIPELINED_DATA, false);
     }
 
     @Test
-    public void editBufferPool() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, BUFFER_POOL, BUFFER_POOL_ATTR, BUFFER_POOL_VALUE_VALID);
+    public void editBufferPool() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, BUFFER_POOL, undertowOps.createBufferPool());
     }
 
     @Test
-    public void setDecodeURLToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, DECODE_URL, DECODE_URL_ATTR, true);
+    public void setDecodeURLToTrue() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, DECODE_URL, true);
     }
 
     @Test
-    public void setDecodeURLToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, DECODE_URL, DECODE_URL_ATTR, false);
+    public void setDecodeURLToFalse() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, DECODE_URL, false);
     }
 
     //@Test
 
     @Test
-    public void setEnabledToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ENABLED, ENABLED_ATTR, true);
+    public void setEnabledToTrue() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, ENABLED, true);
     }
 
     @Test
-    public void setEnabledToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ENABLED, ENABLED_ATTR, false);
+    public void setEnabledToFalse() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, ENABLED, false);
     }
 
     @Test
-    public void editMaxBufferedRequestSize() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_BUFFERED_REQUEST_SIZE, MAX_BUFFERED_REQUEST_SIZE_ATTR, NUMERIC_VALID);
+    public void editMaxBufferedRequestSize() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, MAX_BUFFERED_REQUEST_SIZE, NUMERIC_VALID);
     }
 
     @Test
@@ -202,8 +191,8 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxConnections() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_CONNECTIONS, MAX_CONNECTIONS_ATTR, NUMERIC_VALID);
+    public void editMaxConnections() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, MAX_CONNECTIONS, NUMERIC_VALID);
     }
 
     @Test
@@ -212,8 +201,8 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxCookies() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_COOKIES, MAX_COOKIES_ATTR, NUMERIC_VALID);
+    public void editMaxCookies() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, MAX_COOKIES, NUMERIC_VALID);
     }
 
     @Test
@@ -222,8 +211,8 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxHeaderSize() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_HEADER_SIZE, MAX_HEADER_SIZE_ATTR, NUMERIC_VALID);
+    public void editMaxHeaderSize() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, MAX_HEADER_SIZE, NUMERIC_VALID);
     }
 
     @Test
@@ -232,8 +221,8 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxHeaders() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_HEADERS, MAX_HEADERS_ATTR, NUMERIC_VALID);
+    public void editMaxHeaders() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, MAX_HEADERS, NUMERIC_VALID);
     }
 
     @Test
@@ -242,8 +231,8 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxParameters() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_PARAMETERS, MAX_PARAMETERS_ATTR, NUMERIC_VALID);
+    public void editMaxParameters() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, MAX_PARAMETERS, NUMERIC_VALID);
     }
 
     @Test
@@ -252,8 +241,8 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxPostSize() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_POST_SIZE, MAX_POST_SIZE_ATTR, NUMERIC_VALID);
+    public void editMaxPostSize() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, MAX_POST_SIZE, NUMERIC_VALID_LONG);
     }
 
     @Test
@@ -262,8 +251,8 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editNoRequestTimeout() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, NO_REQUEST_TIMEOUT, NO_REQUEST_TIMEOUT_ATTR, NUMERIC_VALID);
+    public void editNoRequestTimeout() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, NO_REQUEST_TIMEOUT, NUMERIC_VALID);
     }
 
     @Test
@@ -272,8 +261,8 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editReadTimeout() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, READ_TIMEOUT, READ_TIMEOUT_ATTR, NUMERIC_VALID);
+    public void editReadTimeout() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, READ_TIMEOUT, NUMERIC_VALID);
     }
 
     @Test
@@ -282,8 +271,8 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editReceiveBuffer() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, RECEIVE_BUFFER, RECEIVE_BUFFER_ATTR, NUMERIC_VALID);
+    public void editReceiveBuffer() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, RECEIVE_BUFFER, NUMERIC_VALID);
     }
 
     @Test
@@ -292,23 +281,23 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void setRecordRequestStartTimeToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, RECORD_REQUEST_START_TIME, RECORD_REQUEST_START_TIME_ATTR, true);
+    public void setRecordRequestStartTimeToTrue() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, RECORD_REQUEST_START_TIME, true);
     }
 
     @Test
-    public void setRecordRequestStartTimeToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, RECORD_REQUEST_START_TIME, RECORD_REQUEST_START_TIME_ATTR, false);
+    public void setRecordRequestStartTimeToFalse() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, RECORD_REQUEST_START_TIME, false);
     }
 
     @Test
-    public void editRedirectSocket() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, REDIRECT_SOCKET, REDIRECT_SOCKET_ATTR);
+    public void editRedirectSocket() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, REDIRECT_SOCKET, undertowOps.createSocketBinding());
     }
 
     @Test
-    public void editRequestParseTimeout() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, REQUEST_PARSE_TIMEOUT, REQUEST_PARSE_TIMEOUT_ATTR, NUMERIC_VALID);
+    public void editRequestParseTimeout() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, REQUEST_PARSE_TIMEOUT, NUMERIC_VALID);
     }
 
     @Test
@@ -317,23 +306,23 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void setResolvePeerAddressToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, RESOLVE_PEER_ADDRESS, RESOLVE_PEER_ADDRESS_ATTR, true);
+    public void setResolvePeerAddressToTrue() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, RESOLVE_PEER_ADDRESS, true);
     }
 
     @Test
-    public void setResolvePeerAddressToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, RESOLVE_PEER_ADDRESS, RESOLVE_PEER_ADDRESS_ATTR, false);
+    public void setResolvePeerAddressToFalse() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, RESOLVE_PEER_ADDRESS, false);
     }
 
     @Test
-    public void editScheme() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, SCHEME, SCHEME_ATTR);
+    public void editScheme() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, SCHEME);
     }
 
     @Test
-    public void editSendBuffer() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, SEND_BUFFER, SEND_BUFFER_ATTR, NUMERIC_VALID);
+    public void editSendBuffer() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, SEND_BUFFER, NUMERIC_VALID);
     }
 
     @Test
@@ -342,13 +331,13 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editSocketBinding() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, SOCKET_BINDING, SOCKET_BINDING_ATTR, SOCKET_BINDING_VALUE_VALID);
+    public void editSocketBinding() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, SOCKET_BINDING, undertowOps.createSocketBinding());
     }
 
     @Test
-    public void editTCPBacklog() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, TCP_BACKLOG, TCP_BACKLOG_ATTR, NUMERIC_VALID);
+    public void editTCPBacklog() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, TCP_BACKLOG, NUMERIC_VALID);
     }
 
     @Test
@@ -357,31 +346,32 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void setTCPKeepAliveToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, TCP_KEEP_ALIVE, TCP_KEEP_ALIVE_ATTR, true);
+    public void setTCPKeepAliveToTrue() throws Exception {
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, TCP_KEEP_ALIVE, true);
     }
 
     @Test
-    public void setTCPKeepAliveToFalse() throws IOException, InterruptedException, TimeoutException {
-        operations.writeAttribute(address, TCP_KEEP_ALIVE_ATTR, true);
-        operations.reloadIfRequiredAndWaitForRunning();
-        navigate2ajpListener();
-        editCheckboxAndVerify(address, TCP_KEEP_ALIVE, TCP_KEEP_ALIVE_ATTR, false);
+    public void setTCPKeepAliveToFalse() throws Exception {
+        operations.writeAttribute(AJP_LISTENER_ADDRESS, TCP_KEEP_ALIVE, true);
+        administration.reloadIfRequired();
+        page.navigate();
+        page.viewHTTPServer(HTTP_SERVER).switchToAJPListeners().selectItemInTableByText(AJP_LISTENER);
+        editCheckboxAndVerify(AJP_LISTENER_ADDRESS, TCP_KEEP_ALIVE, false);
     }
 
     @Test
-    public void editURLCharset() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, URL_CHARSET, URL_CHARSET_ATTR);
+    public void editURLCharset() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, URL_CHARSET);
     }
 
     @Test
-    public void editWorker() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, WORKER, WORKER_ATTR, WORKER_VALUE_VALID);
+    public void editWorker() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, WORKER, undertowOps.createWorker());
     }
 
     @Test
-    public void editWriteTimeout() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, WRITE_TIMEOUT, WRITE_TIMEOUT_ATTR, NUMERIC_VALID);
+    public void editWriteTimeout() throws Exception {
+        editTextAndVerify(AJP_LISTENER_ADDRESS, WRITE_TIMEOUT, NUMERIC_VALID);
     }
 
     @Test
@@ -390,39 +380,31 @@ public class AJPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void addAJPListenerInGUI() throws IOException, CommandFailedException {
-        String name = "ajpGUI_" + RandomStringUtils.randomAlphanumeric(6);
-        String socketBinding = operations.createSocketBinding();
+    public void addAJPListenerInGUI() throws Exception {
         ConfigFragment config = page.getConfigFragment();
+        String socketBinding = undertowOps.createSocketBinding();
         WizardWindow wizard = config.getResourceManager().addResource();
-
         Editor editor = wizard.getEditor();
-        editor.text("name", name);
+        editor.text("name", AJP_LISTENER_TBA);
         editor.text(SOCKET_BINDING, socketBinding);
-        boolean result = wizard.finish();
+        boolean result = wizard.finishAndDismissReloadRequiredWindow();
 
         Assert.assertTrue("Window should be closed", result);
-        Assert.assertTrue("AJP listener should be present in table", config.resourceIsPresent(name));
-        ResourceAddress address = ajpListenerTemplate.resolve(context, httpServer, name);
-        verifier.verifyResource(address, true);
-        verifier.verifyAttribute(address, SOCKET_BINDING, socketBinding);
+        Assert.assertTrue("AJP listener should be present in table", config.resourceIsPresent(AJP_LISTENER_TBA));
+        new ResourceVerifier(AJP_LISTENER_ADDRESS_TBA, client)
+                .verifyExists()
+                .verifyAttribute(SOCKET_BINDING, socketBinding);
     }
 
     @Test
-    public void removeAJPListenerInGUI() {
+    public void removeAJPListenerInGUI() throws Exception {
         ConfigFragment config = page.getConfigFragment();
         config.getResourceManager()
-                .removeResource(ajpListenerToBeRemoved)
+                .removeResource(AJP_LISTENER_TBR)
                 .confirmAndDismissReloadRequiredMessage();
 
-        ResourceAddress address = ajpListenerTemplate.resolve(context, httpServer, ajpListenerToBeRemoved);
-        Assert.assertFalse("AJP listener host should not be present in table", config.resourceIsPresent(ajpListenerToBeRemoved));
-        verifier.verifyResource(address, false); //HTTP server host should not be present on the server
-    }
-
-    private void navigate2ajpListener() {
-        page.navigate();
-        page.viewHTTPServer(httpServer).switchToAJPListeners();
+        Assert.assertFalse("AJP listener host should not be present in table", config.resourceIsPresent(AJP_LISTENER_TBR));
+        new ResourceVerifier(AJP_LISTENER_ADDRESS_TBR, client).verifyDoesNotExist(); //HTTP server host should not be present on the server
     }
 
 }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/HTTPListenerTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/HTTPListenerTestCase.java
@@ -4,8 +4,7 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.hal.testsuite.category.Shared;
-import org.jboss.hal.testsuite.dmr.AddressTemplate;
-import org.jboss.hal.testsuite.dmr.ResourceAddress;
+import org.jboss.hal.testsuite.creaper.ResourceVerifier;
 import org.jboss.hal.testsuite.fragment.ConfigFragment;
 import org.jboss.hal.testsuite.fragment.formeditor.Editor;
 import org.jboss.hal.testsuite.fragment.shared.modal.WizardWindow;
@@ -17,212 +16,184 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.wildfly.extras.creaper.commands.undertow.AddUndertowListener;
 import org.wildfly.extras.creaper.core.CommandFailedException;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.OperationException;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
-/**
- * @author Jan Kasik <jkasik@redhat.com>
- *         Created on 15.9.15.
- */
 @RunWith(Arquillian.class)
 @Category(Shared.class)
 public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
-
-    private static final Logger log = LoggerFactory.getLogger(HTTPListenerTestCase.class);
 
     @Page
     private UndertowHTTPPage page;
 
     //identifiers
-    private final String ALLOW_ENCODED_SLASH = "allow-encoded-slash";
-    private final String ALLOW_EQUALS_IN_COOKIE_VALUE = "allow-equals-in-cookie-value";
-    private final String ALWAYS_SET_KEEP_ALIVE = "always-set-keep-alive";
-    private final String BUFFER_PIPELINED_DATA = "buffer-pipelined-data";
-    private final String BUFFER_POOL = "buffer-pool";
-    private final String CERTIFICATE_FORWARDING = "certificate-forwarding";
-    private final String DECODE_URL = "decode-url";
-    private final String ENABLE_HTTP2 = "enable-http2";
-    private final String ENABLED = "enabled";
-    private final String MAX_BUFFERED_REQUEST_SIZE = "max-buffered-request-size";
-    private final String MAX_CONNECTIONS = "max-connections";
-    private final String MAX_COOKIES = "max-cookies";
-    private final String MAX_HEADER_SIZE = "max-header-size";
-    private final String MAX_HEADERS = "max-headers";
-    private final String MAX_PARAMETERS = "max-parameters";
-    private final String MAX_POST_SIZE = "max-post-size";
-    private final String NO_REQUEST_TIMEOUT = "no-request-timeout";
-    private final String PROXY_ADDRESS_FORWARDING = "proxy-address-forwarding";
-    private final String READ_TIMEOUT = "read-timeout";
-    private final String RECEIVE_BUFFER = "receive-buffer";
-    private final String RECORD_REQUEST_START_TIME = "record-request-start-time";
-    private final String REDIRECT_SOCKET = "redirect-socket";
-    private final String REQUEST_PARSE_TIMEOUT = "request-parse-timeout";
-    private final String RESOLVE_PEER_ADDRESS = "resolve-peer-address";
-    private final String SEND_BUFFER = "send-buffer";
-    private final String SOCKET_BINDING = "socket-binding";
-    private final String TCP_BACKLOG = "tcp-backlog";
-    private final String TCP_KEEP_ALIVE = "tcp-keep-alive";
-    private final String URL_CHARSET = "url-charset";
-    private final String WORKER = "worker";
-    private final String WRITE_TIMEOUT = "write-timeout";
-
-    //attribute names
-    private final String ALLOW_ENCODED_SLASH_ATTR = "allow-encoded-slash";
-    private final String ALLOW_EQUALS_IN_COOKIE_VALUE_ATTR = "allow-equals-in-cookie-value";
-    private final String ALWAYS_SET_KEEP_ALIVE_ATTR = "always-set-keep-alive";
-    private final String BUFFER_PIPELINED_DATA_ATTR = "buffer-pipelined-data";
-    private final String CERTIFICATE_FORWARDING_ATTR = "certificate-forwarding";
-    private final String BUFFER_POOL_ATTR = "buffer-pool";
-    private final String DECODE_URL_ATTR = "decode-url";
-    private final String ENABLE_HTTP2_ATTR = "enable-http2";
-    private final String ENABLED_ATTR = "enabled";
-    private final String MAX_BUFFERED_REQUEST_SIZE_ATTR = "max-buffered-request-size";
-    private final String MAX_CONNECTIONS_ATTR = "max-connections";
-    private final String MAX_COOKIES_ATTR = "max-cookies";
-    private final String MAX_HEADER_SIZE_ATTR = "max-header-size";
-    private final String MAX_HEADERS_ATTR = "max-headers";
-    private final String MAX_PARAMETERS_ATTR = "max-parameters";
-    private final String MAX_POST_SIZE_ATTR = "max-post-size";
-    private final String NO_REQUEST_TIMEOUT_ATTR = "no-request-timeout";
-    private final String PROXY_ADDRESS_FORWARDING_ATTR = "proxy-address-forwarding";
-    private final String READ_TIMEOUT_ATTR = "read-timeout";
-    private final String RECEIVE_BUFFER_ATTR = "receive-buffer";
-    private final String RECORD_REQUEST_START_TIME_ATTR = "record-request-start-time";
-    private final String REDIRECT_SOCKET_ATTR = "redirect-socket";
-    private final String REQUEST_PARSE_TIMEOUT_ATTR = "request-parse-timeout";
-    private final String RESOLVE_PEER_ADDRESS_ATTR = "resolve-peer-address";
-    private final String SEND_BUFFER_ATTR = "send-buffer";
-    private final String SOCKET_BINDING_ATTR = "socket-binding";
-    private final String TCP_BACKLOG_ATTR = "tcp-backlog";
-    private final String TCP_KEEP_ALIVE_ATTR = "tcp-keep-alive";
-    private final String URL_CHARSET_ATTR = "url-charset";
-    private final String WORKER_ATTR = "worker";
-    private final String WRITE_TIMEOUT_ATTR = "write-timeout";
+    private static final String ALLOW_ENCODED_SLASH = "allow-encoded-slash";
+    private static final String ALLOW_EQUALS_IN_COOKIE_VALUE = "allow-equals-in-cookie-value";
+    private static final String ALWAYS_SET_KEEP_ALIVE = "always-set-keep-alive";
+    private static final String BUFFER_PIPELINED_DATA = "buffer-pipelined-data";
+    private static final String BUFFER_POOL = "buffer-pool";
+    private static final String CERTIFICATE_FORWARDING = "certificate-forwarding";
+    private static final String DECODE_URL = "decode-url";
+    private static final String ENABLE_HTTP2 = "enable-http2";
+    private static final String ENABLED = "enabled";
+    private static final String MAX_BUFFERED_REQUEST_SIZE = "max-buffered-request-size";
+    private static final String MAX_CONNECTIONS = "max-connections";
+    private static final String MAX_COOKIES = "max-cookies";
+    private static final String MAX_HEADER_SIZE = "max-header-size";
+    private static final String MAX_HEADERS = "max-headers";
+    private static final String MAX_PARAMETERS = "max-parameters";
+    private static final String MAX_POST_SIZE = "max-post-size";
+    private static final String NO_REQUEST_TIMEOUT = "no-request-timeout";
+    private static final String PROXY_ADDRESS_FORWARDING = "proxy-address-forwarding";
+    private static final String READ_TIMEOUT = "read-timeout";
+    private static final String RECEIVE_BUFFER = "receive-buffer";
+    private static final String RECORD_REQUEST_START_TIME = "record-request-start-time";
+    private static final String REDIRECT_SOCKET = "redirect-socket";
+    private static final String REQUEST_PARSE_TIMEOUT = "request-parse-timeout";
+    private static final String RESOLVE_PEER_ADDRESS = "resolve-peer-address";
+    private static final String SEND_BUFFER = "send-buffer";
+    private static final String SOCKET_BINDING = "socket-binding";
+    private static final String TCP_BACKLOG = "tcp-backlog";
+    private static final String TCP_KEEP_ALIVE = "tcp-keep-alive";
+    private static final String URL_CHARSET = "url-charset";
+    private static final String WORKER = "worker";
+    private static final String WRITE_TIMEOUT = "write-timeout";
 
     //values
-    private final String NUMERIC_VALID = "25";
-    private final String NUMERIC_INVALID = "25fazf";
+    private static final String HTTP_SERVER = "undertow-http-server-http-listener_" + RandomStringUtils.randomAlphanumeric(5);
 
-    private static AddressTemplate httpListenerTemplate = httpServerTemplate.append("/http-listener=*");
-    private static String httpServer;
-    private static String httpListener;
-    private static String httpListenerToBeRemoved;
-    private static ResourceAddress address;
+    private static final String HTTP_LISTENER = "http-listener_" + RandomStringUtils.randomAlphanumeric(5);
+    private static final String HTTP_LISTENER_TBR = "http-listener-tbr_" + RandomStringUtils.randomAlphanumeric(5);
+    private static final String HTTP_LISTENER_TBA = "http-listener-tba_" + RandomStringUtils.randomAlphanumeric(5);
+
+    private static final Address HTTP_SERVER_ADDRESS = UNDERTOW_ADDRESS.and("server", HTTP_SERVER);
+
+    private static final Address HTTP_LISTENER_ADDRESS = HTTP_SERVER_ADDRESS.and("http-listener", HTTP_LISTENER);
+    private static final Address HTTP_LISTENER_TBR_ADDRESS = HTTP_SERVER_ADDRESS.and("http-listener", HTTP_LISTENER_TBR);
+    private static final Address HTTP_LISTENER_TBA_ADDRESS = HTTP_SERVER_ADDRESS.and("http-listener", HTTP_LISTENER_TBA);
 
     @BeforeClass
     public static void setUp() throws IOException, CommandFailedException, TimeoutException, InterruptedException {
-        httpServer = operations.createHTTPServer();
-        httpListenerToBeRemoved = operations.createHTTPListener(httpServer);
-        httpListener = operations.createHTTPListener(httpServer);
-        address = httpListenerTemplate.resolve(context, httpServer, httpListener);
-        log.info("Address is " + address);
+        operations.add(HTTP_SERVER_ADDRESS);
+        administration.reloadIfRequired();
+        client.apply(new AddUndertowListener
+                .HttpBuilder(HTTP_LISTENER, HTTP_SERVER, undertowOps.createSocketBinding()).build());
+        client.apply(new AddUndertowListener
+                .HttpBuilder(HTTP_LISTENER_TBR, HTTP_SERVER, undertowOps.createSocketBindingWithoutReference()).build());
+        administration.reloadIfRequired();
     }
 
     @Before
     public void before() {
-        navigate2httpListener();
+        page.navigate();
+        page.viewHTTPServer(HTTP_SERVER)
+                .switchToHTTPListeners()
+                .selectItemInTableByText(HTTP_LISTENER);
     }
 
     @AfterClass
-    public static void tearDown() throws InterruptedException, CommandFailedException, TimeoutException, IOException {
-        operations.removeHTTPListener(httpServer, httpListener);
-        operations.removeHTTPServer(httpServer);
+    public static void tearDown() throws InterruptedException, CommandFailedException, TimeoutException, IOException, OperationException {
+        operations.removeIfExists(HTTP_LISTENER_ADDRESS);
+        operations.removeIfExists(HTTP_LISTENER_TBA_ADDRESS);
+        operations.removeIfExists(HTTP_LISTENER_TBR_ADDRESS);
+        operations.removeIfExists(HTTP_SERVER_ADDRESS);
     }
 
     @Test
-    public void setAllowEncodedSlashToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALLOW_ENCODED_SLASH, ALLOW_ENCODED_SLASH_ATTR, true);
+    public void setAllowEncodedSlashToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, ALLOW_ENCODED_SLASH, true);
     }
 
     @Test
-    public void setAllowEncodedSlashToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALLOW_ENCODED_SLASH, ALLOW_ENCODED_SLASH_ATTR, false);
+    public void setAllowEncodedSlashToFalse() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, ALLOW_ENCODED_SLASH, false);
     }
 
     @Test
-    public void setAllowEqualsInCookieValueToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALLOW_EQUALS_IN_COOKIE_VALUE, ALLOW_EQUALS_IN_COOKIE_VALUE_ATTR, true);
+    public void setAllowEqualsInCookieValueToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, ALLOW_EQUALS_IN_COOKIE_VALUE, true);
     }
 
     @Test
-    public void setAllowEqualsInCookieValueToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALLOW_EQUALS_IN_COOKIE_VALUE, ALLOW_EQUALS_IN_COOKIE_VALUE_ATTR, false);
+    public void setAllowEqualsInCookieValueToFalse() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, ALLOW_EQUALS_IN_COOKIE_VALUE, false);
     }
 
     @Test
-    public void setAlwaysSetKeepAliveToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALWAYS_SET_KEEP_ALIVE, ALWAYS_SET_KEEP_ALIVE_ATTR, true);
+    public void setAlwaysSetKeepAliveToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, ALWAYS_SET_KEEP_ALIVE, true);
     }
 
     @Test
-    public void setAlwaysSetKeepAliveToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALWAYS_SET_KEEP_ALIVE, ALWAYS_SET_KEEP_ALIVE_ATTR, false);
+    public void setAlwaysSetKeepAliveToFalse() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, ALWAYS_SET_KEEP_ALIVE, false);
     }
 
     @Test
-    public void setBufferPipelinedDataToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, BUFFER_PIPELINED_DATA, BUFFER_PIPELINED_DATA_ATTR, true);
+    public void setBufferPipelinedDataToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, BUFFER_PIPELINED_DATA, true);
     }
 
     @Test
-    public void setBufferPipelinedDataToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, BUFFER_PIPELINED_DATA, BUFFER_PIPELINED_DATA_ATTR, false);
+    public void setBufferPipelinedDataToFalse() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, BUFFER_PIPELINED_DATA, false);
     }
 
     @Test
-    public void editBufferPool() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, BUFFER_POOL, BUFFER_POOL_ATTR, BUFFER_POOL_VALUE_VALID);
+    public void editBufferPool() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, BUFFER_POOL, undertowOps.createBufferPool());
     }
 
     @Test
-    public void setCertificateForwardingToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, CERTIFICATE_FORWARDING, CERTIFICATE_FORWARDING_ATTR, true);
+    public void setCertificateForwardingToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, CERTIFICATE_FORWARDING, true);
     }
 
     @Test
-    public void setCertificateForwardingToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, CERTIFICATE_FORWARDING, CERTIFICATE_FORWARDING_ATTR, false);
+    public void setCertificateForwardingToFalse() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, CERTIFICATE_FORWARDING, false);
     }
 
     @Test
-    public void setDecodeURLToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, DECODE_URL, DECODE_URL_ATTR, true);
+    public void setDecodeURLToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, DECODE_URL, true);
     }
 
     @Test
-    public void setDecodeURLToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, DECODE_URL, DECODE_URL_ATTR, false);
+    public void setDecodeURLToFalse() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, DECODE_URL, false);
     }
 
     //TODO:DISALLOWED METHODS
 
     @Test
-    public void setEnableHTTP2ToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ENABLE_HTTP2, ENABLE_HTTP2_ATTR, true);
+    public void setEnableHTTP2ToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, ENABLE_HTTP2, true);
     }
 
     @Test
-    public void setEnableHTTP2ToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ENABLE_HTTP2, ENABLE_HTTP2_ATTR, false);
+    public void setEnableHTTP2ToFalse() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, ENABLE_HTTP2, false);
     }
 
     @Test
-    public void setEnabledToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ENABLED, ENABLED_ATTR, true);
+    public void setEnabledToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, ENABLED, true);
     }
 
     @Test
-    public void setEnabledToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ENABLED, ENABLED_ATTR, false);
+    public void setEnabledToFalse() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, ENABLED, false);
     }
 
     @Test
-    public void editMaxBufferedRequestSize() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_BUFFERED_REQUEST_SIZE, MAX_BUFFERED_REQUEST_SIZE_ATTR, NUMERIC_VALID);
+    public void editMaxBufferedRequestSize() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, MAX_BUFFERED_REQUEST_SIZE, NUMERIC_VALID);
     }
 
     @Test
@@ -231,8 +202,8 @@ public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxConnections() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_CONNECTIONS, MAX_CONNECTIONS_ATTR, NUMERIC_VALID);
+    public void editMaxConnections() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, MAX_CONNECTIONS, NUMERIC_VALID);
     }
 
     @Test
@@ -241,8 +212,8 @@ public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxCookies() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_COOKIES, MAX_COOKIES_ATTR, NUMERIC_VALID);
+    public void editMaxCookies() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, MAX_COOKIES, NUMERIC_VALID);
     }
 
     @Test
@@ -251,8 +222,8 @@ public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxHeaderSize() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_HEADER_SIZE, MAX_HEADER_SIZE_ATTR, NUMERIC_VALID);
+    public void editMaxHeaderSize() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, MAX_HEADER_SIZE, NUMERIC_VALID);
     }
 
     @Test
@@ -261,8 +232,8 @@ public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxHeaders() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_HEADERS, MAX_HEADERS_ATTR, NUMERIC_VALID);
+    public void editMaxHeaders() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, MAX_HEADERS, NUMERIC_VALID);
     }
 
     @Test
@@ -271,8 +242,8 @@ public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxParameters() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_PARAMETERS, MAX_PARAMETERS_ATTR, NUMERIC_VALID);
+    public void editMaxParameters() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, MAX_PARAMETERS, NUMERIC_VALID);
     }
 
     @Test
@@ -281,8 +252,8 @@ public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editMaxPostSize() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_POST_SIZE, MAX_POST_SIZE_ATTR, NUMERIC_VALID);
+    public void editMaxPostSize() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, MAX_POST_SIZE, NUMERIC_VALID_LONG);
     }
 
     @Test
@@ -291,8 +262,8 @@ public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void editNoRequestTimeout() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, NO_REQUEST_TIMEOUT, NO_REQUEST_TIMEOUT_ATTR, NUMERIC_VALID);
+    public void editNoRequestTimeout() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, NO_REQUEST_TIMEOUT, NUMERIC_VALID);
     }
 
     @Test
@@ -301,28 +272,28 @@ public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void setProxyAddressForwardingToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, PROXY_ADDRESS_FORWARDING, PROXY_ADDRESS_FORWARDING_ATTR, true);
+    public void setProxyAddressForwardingToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, PROXY_ADDRESS_FORWARDING, true);
     }
 
     @Test
-    public void setProxyAddressForwardingToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, PROXY_ADDRESS_FORWARDING, PROXY_ADDRESS_FORWARDING_ATTR, false);
+    public void setProxyAddressForwardingToFalse() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, PROXY_ADDRESS_FORWARDING, false);
     }
 
     @Test
-    public void editReadTimeout() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, READ_TIMEOUT, READ_TIMEOUT_ATTR, NUMERIC_VALID);
+    public void editReadTimeout() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, READ_TIMEOUT, NUMERIC_VALID);
     }
 
     @Test
-    public void editReadTimeoutInvalid() throws IOException, InterruptedException, TimeoutException {
+    public void editReadTimeoutInvalid() throws Exception {
         verifyIfErrorAppears(READ_TIMEOUT, NUMERIC_INVALID);
     }
 
     @Test
-    public void editReceiveBuffer() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, RECEIVE_BUFFER, RECEIVE_BUFFER_ATTR, NUMERIC_VALID);
+    public void editReceiveBuffer() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, RECEIVE_BUFFER, NUMERIC_VALID);
     }
 
     @Test
@@ -331,58 +302,58 @@ public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void setRecordRequestStartTimeToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, RECORD_REQUEST_START_TIME, RECORD_REQUEST_START_TIME_ATTR, true);
+    public void setRecordRequestStartTimeToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, RECORD_REQUEST_START_TIME, true);
     }
 
     @Test
-    public void setRecordRequestStartTimeToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, RECORD_REQUEST_START_TIME, RECORD_REQUEST_START_TIME_ATTR, false);
+    public void setRecordRequestStartTimeToFalse() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, RECORD_REQUEST_START_TIME, false);
     }
 
     @Test
-    public void editRedirectSocket() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, REDIRECT_SOCKET, REDIRECT_SOCKET_ATTR, SOCKET_BINDING_VALUE_VALID);
+    public void editRedirectSocket() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, REDIRECT_SOCKET, undertowOps.createSocketBinding());
     }
 
     @Test
-    public void editRequestParseTimeout() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, REQUEST_PARSE_TIMEOUT, REQUEST_PARSE_TIMEOUT_ATTR, NUMERIC_VALID);
+    public void editRequestParseTimeout() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, REQUEST_PARSE_TIMEOUT, NUMERIC_VALID);
     }
 
     @Test
-    public void editRequestParseTimeoutInvalid() throws IOException, InterruptedException, TimeoutException {
+    public void editRequestParseTimeoutInvalid() throws Exception {
         verifyIfErrorAppears(REQUEST_PARSE_TIMEOUT, NUMERIC_INVALID);
     }
 
     @Test
-    public void setResolvePeerAddressToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, RESOLVE_PEER_ADDRESS, RESOLVE_PEER_ADDRESS_ATTR, true);
+    public void setResolvePeerAddressToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, RESOLVE_PEER_ADDRESS, true);
     }
 
     @Test
-    public void setResolvePeerAddressToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, RESOLVE_PEER_ADDRESS, RESOLVE_PEER_ADDRESS_ATTR, false);
+    public void setResolvePeerAddressToFalse() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, RESOLVE_PEER_ADDRESS, false);
     }
 
     @Test
-    public void editSendBuffer() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, SEND_BUFFER, SEND_BUFFER_ATTR, NUMERIC_VALID);
+    public void editSendBuffer() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, SEND_BUFFER, NUMERIC_VALID);
     }
 
     @Test
-    public void editSendBufferInvalid() throws IOException, InterruptedException, TimeoutException {
+    public void editSendBufferInvalid() throws Exception {
         verifyIfErrorAppears(SEND_BUFFER, NUMERIC_INVALID);
     }
 
     @Test
-    public void editSocketBinding() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, SOCKET_BINDING, SOCKET_BINDING_ATTR, SOCKET_BINDING_VALUE_VALID);
+    public void editSocketBinding() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, SOCKET_BINDING, undertowOps.createSocketBinding());
     }
 
     @Test
-    public void editTCPBacklog() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, TCP_BACKLOG, TCP_BACKLOG_ATTR, NUMERIC_VALID);
+    public void editTCPBacklog() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, TCP_BACKLOG, NUMERIC_VALID);
     }
 
     @Test
@@ -391,72 +362,69 @@ public class HTTPListenerTestCase extends UndertowTestCaseAbstract {
     }
 
     @Test
-    public void setTCPKeepAliveToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, TCP_KEEP_ALIVE, TCP_KEEP_ALIVE_ATTR, true);
+    public void setTCPKeepAliveToTrue() throws Exception {
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, TCP_KEEP_ALIVE, true);
     }
 
     @Test
-    public void setTCPKeepAliveToFalse() throws IOException, InterruptedException, TimeoutException {
-        operations.writeAttribute(address, TCP_KEEP_ALIVE_ATTR, true);
-        operations.reloadIfRequiredAndWaitForRunning();
-        navigate2httpListener();
-        editCheckboxAndVerify(address, TCP_KEEP_ALIVE, TCP_KEEP_ALIVE_ATTR, false);
+    public void setTCPKeepAliveToFalse() throws Exception {
+        operations.writeAttribute(HTTP_LISTENER_ADDRESS, TCP_KEEP_ALIVE, true);
+        administration.reloadIfRequired();
+        page.navigate();
+        page.viewHTTPServer(HTTP_SERVER)
+                .switchToHTTPListeners()
+                .selectItemInTableByText(HTTP_LISTENER);
+        editCheckboxAndVerify(HTTP_LISTENER_ADDRESS, TCP_KEEP_ALIVE, false);
     }
 
     @Test
-    public void editURLCharset() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, URL_CHARSET, URL_CHARSET_ATTR);
+    public void editURLCharset() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, URL_CHARSET);
     }
 
     @Test
-    public void editWorker() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, WORKER, WORKER_ATTR, WORKER_VALUE_VALID);
+    public void editWorker() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, WORKER, undertowOps.createWorker());
     }
 
     @Test
-    public void editWriteTimeout() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, WRITE_TIMEOUT, WRITE_TIMEOUT_ATTR, NUMERIC_VALID);
+    public void editWriteTimeout() throws Exception {
+        editTextAndVerify(HTTP_LISTENER_ADDRESS, WRITE_TIMEOUT, NUMERIC_VALID);
     }
 
     @Test
-    public void editWriteTimeoutInvalid() throws IOException, InterruptedException, TimeoutException {
+    public void editWriteTimeoutInvalid() throws Exception {
         verifyIfErrorAppears(WRITE_TIMEOUT, NUMERIC_INVALID);
     }
 
     @Test
-    public void addHTTPListenerInGUI() throws InterruptedException, CommandFailedException, TimeoutException, IOException {
-        String name = "httpListener_" + RandomStringUtils.randomAlphanumeric(6);
+    public void addHTTPListenerInGUI() throws Exception {
+        String socketBinding = undertowOps.createSocketBinding();
         ConfigFragment config = page.getConfigFragment();
         WizardWindow wizard = config.getResourceManager().addResource();
 
         Editor editor = wizard.getEditor();
-        editor.text("name", name);
-        editor.text(SOCKET_BINDING, SOCKET_BINDING_VALUE_VALID);
-        boolean result = wizard.finish();
+        editor.text("name", HTTP_LISTENER_TBA);
+        editor.text(SOCKET_BINDING, socketBinding);
+        boolean result = wizard.finishAndDismissReloadRequiredWindow();
 
         Assert.assertTrue("Window should be closed", result);
-        Assert.assertTrue("HTTP listener should be present in table", config.resourceIsPresent(name));
-        ResourceAddress address = httpListenerTemplate.resolve(context, httpServer, name);
-        verifier.verifyResource(address, true);
-        verifier.verifyAttribute(address, SOCKET_BINDING, SOCKET_BINDING_VALUE_VALID);
-        operations.removeHTTPListener(httpServer, name);
+        Assert.assertTrue("HTTP listener should be present in table", config.resourceIsPresent(HTTP_LISTENER_TBA));
+        ResourceVerifier verifier = new ResourceVerifier(HTTP_LISTENER_TBA_ADDRESS, client);
+        verifier.verifyExists();
+        verifier.verifyAttribute(SOCKET_BINDING, socketBinding);
     }
 
     @Test
-    public void removeHTTPListenerInGUI() {
+    public void removeHTTPListenerInGUI() throws Exception {
         ConfigFragment config = page.getConfigFragment();
         config.getResourceManager()
-                .removeResource(httpListenerToBeRemoved)
+                .removeResource(HTTP_LISTENER_TBR)
                 .confirmAndDismissReloadRequiredMessage();
 
-        ResourceAddress address = httpListenerTemplate.resolve(context, httpServer, httpListenerToBeRemoved);
-        Assert.assertFalse("HTTP listener host should not be present in table", config.resourceIsPresent(httpListenerToBeRemoved));
-        verifier.verifyResource(address, false); //HTTP server host should not be present on the server
+        Assert.assertFalse("HTTP listener host should not be present in table", config.resourceIsPresent(HTTP_LISTENER_TBR));
+        new ResourceVerifier(HTTP_LISTENER_TBR_ADDRESS, client).verifyDoesNotExist(); //HTTP server host should not be present on the server
     }
 
-    private void navigate2httpListener() {
-        page.navigate();
-        page.viewHTTPServer(httpServer).switchToHTTPListeners().selectItemInTableByText(httpListener);
-    }
 
 }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/ServletContainerTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/ServletContainerTestCase.java
@@ -1,9 +1,9 @@
 package org.jboss.hal.testsuite.test.configuration.undertow;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.hal.testsuite.category.Shared;
-import org.jboss.hal.testsuite.dmr.ResourceAddress;
 import org.jboss.hal.testsuite.page.config.UndertowServletPage;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -11,15 +11,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.operations.Address;
 import org.wildfly.extras.creaper.core.online.operations.OperationException;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
-/**
- * @author Jan Kasik <jkasik@redhat.com>
- *         Created on 17.9.15.
- */
 @RunWith(Arquillian.class)
 @Category(Shared.class)
 public class ServletContainerTestCase extends UndertowTestCaseAbstract {
@@ -28,137 +25,121 @@ public class ServletContainerTestCase extends UndertowTestCaseAbstract {
     private UndertowServletPage page;
 
     //identifiers
-    private final String ALLOW_NON_STANDARD_WRAPPERS = "allow-non-standard-wrappers";
-    private final String DEFAULT_BUFFER_CACHE = "default-buffer-cache";
-    private final String DEFAULT_ENCODING = "default-encoding";
-    private final String DEFAULT_SESSION_TIMEOUT = "default-session-timeout";
-    private final String DIRECTORY_LISTING = "directory-listing";
-    private final String DISABLE_CACHING_FOR_SECURED_PAGES = "disable-caching-for-secured-pages";
-    private final String EAGER_FILTER_INITIALIZATION = "eager-filter-initialization";
-    private final String IGNORE_FLUSH = "ignore-flush";
-    private final String STACK_TRACE_ON_ERROR = "stack-trace-on-error";
-    private final String USE_LISTENER_ENCODING = "use-listener-encoding";
-
-    //attribute names
-    private final String ALLOW_NON_STANDARD_WRAPPERS_ATTR = "allow-non-standard-wrappers";
-    private final String DEFAULT_BUFFER_CACHE_ATTR = "default-buffer-cache";
-    private final String DEFAULT_ENCODING_ATTR = "default-encoding";
-    private final String DEFAULT_SESSION_TIMEOUT_ATTR = "default-session-timeout";
-    private final String DIRECTORY_LISTING_ATTR = "directory-listing";
-    private final String DISABLE_CACHING_FOR_SECURED_PAGES_ATTR = "disable-caching-for-secured-pages";
-    private final String EAGER_FILTER_INITIALIZATION_ATTR = "eager-filter-initialization";
-    private final String IGNORE_FLUSH_ATTR = "ignore-flush";
-    private final String STACK_TRACE_ON_ERROR_ATTR = "stack-trace-on-error";
-    private final String USE_LISTENER_ENCODING_ATTR = "use-listener-encoding";
+    private static final String ALLOW_NON_STANDARD_WRAPPERS = "allow-non-standard-wrappers";
+    private static final String DEFAULT_BUFFER_CACHE = "default-buffer-cache";
+    private static final String DEFAULT_ENCODING = "default-encoding";
+    private static final String DEFAULT_SESSION_TIMEOUT = "default-session-timeout";
+    private static final String DIRECTORY_LISTING = "directory-listing";
+    private static final String DISABLE_CACHING_FOR_SECURED_PAGES = "disable-caching-for-secured-pages";
+    private static final String EAGER_FILTER_INITIALIZATION = "eager-filter-initialization";
+    private static final String IGNORE_FLUSH = "ignore-flush";
+    private static final String STACK_TRACE_ON_ERROR = "stack-trace-on-error";
+    private static final String USE_LISTENER_ENCODING = "use-listener-encoding";
 
     //values
-    private final String STACK_TRACE_ON_ERROR_VALUE = "all";
-    protected static String BUFFER_CACHE_VALUE_VALID;
+    private static final String STACK_TRACE_ON_ERROR_VALUE = "all";
 
-    private static String servletContainer;
-    private static ResourceAddress address;
+    private static final String SERVLET_CONTAINER = "servlet-container_" + RandomStringUtils.randomAlphanumeric(5);
+    private static final Address SERVLET_CONTAINER_ADDRESS = UNDERTOW_ADDRESS.and("servlet-container", SERVLET_CONTAINER);
 
     @BeforeClass
     public static void setUp() throws InterruptedException, IOException, TimeoutException {
-        servletContainer = operations.createServletContainer();
-        address = servletContainerTemplate.resolve(context, servletContainer);
-        BUFFER_CACHE_VALUE_VALID = operations.addBufferCache();
+        operations.add(SERVLET_CONTAINER_ADDRESS);
     }
 
     @Before
     public void before() {
         page.navigate();
-        page.selectServletContainer(servletContainer);
+        page.selectServletContainer(SERVLET_CONTAINER);
     }
 
     @AfterClass
     public static void tearDown() throws InterruptedException, IOException, TimeoutException, OperationException {
-        operations.removeServletContainer(servletContainer);
-        operations.removeBufferCache(BUFFER_CACHE_VALUE_VALID);
+        operations.remove(SERVLET_CONTAINER_ADDRESS);
     }
 
     @Test
-    public void setAllowNonStandardWrappersToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALLOW_NON_STANDARD_WRAPPERS, ALLOW_NON_STANDARD_WRAPPERS_ATTR, true);
+    public void setAllowNonStandardWrappersToTrue() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, ALLOW_NON_STANDARD_WRAPPERS, true);
     }
 
     @Test
-    public void setAllowNonStandardWrappersToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, ALLOW_NON_STANDARD_WRAPPERS, ALLOW_NON_STANDARD_WRAPPERS_ATTR, false);
+    public void setAllowNonStandardWrappersToFalse() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, ALLOW_NON_STANDARD_WRAPPERS, false);
     }
 
     @Test
-    public void editDefaultBufferCache() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, DEFAULT_BUFFER_CACHE, DEFAULT_BUFFER_CACHE_ATTR, BUFFER_CACHE_VALUE_VALID);
+    public void editDefaultBufferCache() throws Exception {
+        editTextAndVerify(SERVLET_CONTAINER_ADDRESS, DEFAULT_BUFFER_CACHE, undertowOps.createBufferCache());
     }
 
     @Test
-    public void editDefaultEncoding() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, DEFAULT_ENCODING, DEFAULT_ENCODING_ATTR);
+    public void editDefaultEncoding() throws Exception {
+        editTextAndVerify(SERVLET_CONTAINER_ADDRESS, DEFAULT_ENCODING);
     }
 
     @Test
-    public void editDefaultSessionTimeout() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, DEFAULT_SESSION_TIMEOUT, DEFAULT_SESSION_TIMEOUT_ATTR, "42");
+    public void editDefaultSessionTimeout() throws Exception {
+        editTextAndVerify(SERVLET_CONTAINER_ADDRESS, DEFAULT_SESSION_TIMEOUT, 42);
     }
 
     @Test
-    public void editDefaultSessionTimeoutInvalid() throws IOException, InterruptedException, TimeoutException {
+    public void editDefaultSessionTimeoutInvalid() throws Exception {
         verifyIfErrorAppears(DEFAULT_SESSION_TIMEOUT, "54sdfg");
     }
 
     @Test
-    public void setDirectoryListingToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, DIRECTORY_LISTING, DIRECTORY_LISTING_ATTR, true);
+    public void setDirectoryListingToTrue() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, DIRECTORY_LISTING, true);
     }
 
     @Test
-    public void setDirectoryListingToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, DIRECTORY_LISTING, DIRECTORY_LISTING_ATTR, false);
+    public void setDirectoryListingToFalse() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, DIRECTORY_LISTING, false);
     }
 
     @Test
-    public void setDisableCachingForSecuredPagesToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, DISABLE_CACHING_FOR_SECURED_PAGES, DISABLE_CACHING_FOR_SECURED_PAGES_ATTR, true);
+    public void setDisableCachingForSecuredPagesToTrue() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, DISABLE_CACHING_FOR_SECURED_PAGES, true);
     }
 
     @Test
-    public void setDisableCachingForSecuredPagesToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, DISABLE_CACHING_FOR_SECURED_PAGES, DISABLE_CACHING_FOR_SECURED_PAGES_ATTR, false);
+    public void setDisableCachingForSecuredPagesToFalse() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, DISABLE_CACHING_FOR_SECURED_PAGES, false);
     }
 
     @Test
-    public void setIgnoreFlushToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, IGNORE_FLUSH, IGNORE_FLUSH_ATTR, true);
+    public void setIgnoreFlushToTrue() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, IGNORE_FLUSH, true);
     }
 
     @Test
-    public void setIgnoreFlushToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, IGNORE_FLUSH, IGNORE_FLUSH_ATTR, false);
+    public void setIgnoreFlushToFalse() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, IGNORE_FLUSH, false);
     }
 
     @Test
-    public void setEagerFilterInitializationToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, EAGER_FILTER_INITIALIZATION, EAGER_FILTER_INITIALIZATION_ATTR, true);
+    public void setEagerFilterInitializationToTrue() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, EAGER_FILTER_INITIALIZATION, true);
     }
 
     @Test
-    public void setEagerFilterInitializationToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, EAGER_FILTER_INITIALIZATION, EAGER_FILTER_INITIALIZATION_ATTR, false);
+    public void setEagerFilterInitializationToFalse() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, EAGER_FILTER_INITIALIZATION, false);
     }
 
     @Test
-    public void selectStackTraceOnError() throws IOException, InterruptedException, TimeoutException {
-        selectOptionAndVerify(address, STACK_TRACE_ON_ERROR, STACK_TRACE_ON_ERROR_ATTR, STACK_TRACE_ON_ERROR_VALUE);
+    public void selectStackTraceOnError() throws Exception {
+        selectOptionAndVerify(SERVLET_CONTAINER_ADDRESS, STACK_TRACE_ON_ERROR, STACK_TRACE_ON_ERROR_VALUE);
     }
 
     @Test
-    public void setUseListenerEncodingToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, USE_LISTENER_ENCODING, USE_LISTENER_ENCODING_ATTR, true);
+    public void setUseListenerEncodingToTrue() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, USE_LISTENER_ENCODING, true);
     }
 
     @Test
-    public void setUseListenerEncodingToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, USE_LISTENER_ENCODING, USE_LISTENER_ENCODING_ATTR, false);
+    public void setUseListenerEncodingToFalse() throws Exception {
+        editCheckboxAndVerify(SERVLET_CONTAINER_ADDRESS, USE_LISTENER_ENCODING, false);
     }
 }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/ServletCookiesTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/ServletCookiesTestCase.java
@@ -1,9 +1,9 @@
 package org.jboss.hal.testsuite.test.configuration.undertow;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.hal.testsuite.category.Shared;
-import org.jboss.hal.testsuite.dmr.ResourceAddress;
 import org.jboss.hal.testsuite.page.config.UndertowServletPage;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -11,14 +11,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.operations.Address;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
-/**
- * @author Jan Kasik <jkasik@redhat.com>
- *         Created on 17.9.15.
- */
 @RunWith(Arquillian.class)
 @Category(Shared.class)
 public class ServletCookiesTestCase extends UndertowTestCaseAbstract {
@@ -27,83 +24,76 @@ public class ServletCookiesTestCase extends UndertowTestCaseAbstract {
     private UndertowServletPage page;
 
     //identifiers
-    private final String COMMENT = "comment";
-    private final String DOMAIN = "domain";
-    private final String HTTP_ONLY = "http-only";
-    private final String MAX_AGE = "max-age";
-    private final String NAME = "name";
-    private final String SECURE = "secure";
+    private static final String COMMENT = "comment";
+    private static final String DOMAIN = "domain";
+    private static final String HTTP_ONLY = "http-only";
+    private static final String MAX_AGE = "max-age";
+    private static final String NAME = "name";
+    private static final String SECURE = "secure";
 
-    //attribute names
-    private final String COMMENT_ATTR = "comment";
-    private final String DOMAIN_ATTR = "domain";
-    private final String HTTP_ONLY_ATTR = "http-only";
-    private final String MAX_AGE_ATTR = "max-age";
-    private final String NAME_ATTR = "name";
-    private final String SECURE_ATTR = "secure";
+    private static final String SERVLET_CONTAINER = "servlet-container_" + RandomStringUtils.randomAlphanumeric(5);
+    private static final Address SERVLET_CONTAINER_ADDRESS = UNDERTOW_ADDRESS.and("servlet-container", SERVLET_CONTAINER);
+    private static final Address SESSION_COOKIE_ADDRESS = SERVLET_CONTAINER_ADDRESS.and("setting", "session-cookie");
 
-    private static String servletContainer;
-    private static ResourceAddress address;
 
     @BeforeClass
     public static void setUp() throws InterruptedException, IOException, TimeoutException {
-        servletContainer = operations.createServletContainer();
-        address = servletContainerTemplate.append("/setting=session-cookie").resolve(context, servletContainer);
+        operations.add(SERVLET_CONTAINER_ADDRESS);
     }
 
     @Before
     public void before() {
         page.navigate();
-        page.viewServletContainer(servletContainer).switchToCookies();
+        page.viewServletContainer(SERVLET_CONTAINER).switchToCookies();
     }
 
     @AfterClass
     public static void tearDown() throws InterruptedException, IOException, TimeoutException {
-        operations.removeServletContainer(servletContainer);
+        operations.remove(SERVLET_CONTAINER_ADDRESS);
     }
 
     @Test
-    public void editComment() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, COMMENT, COMMENT_ATTR);
+    public void editComment() throws Exception {
+        editTextAndVerify(SESSION_COOKIE_ADDRESS, COMMENT);
     }
 
     @Test
-    public void editDomain() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, DOMAIN, DOMAIN_ATTR);
+    public void editDomain() throws Exception {
+        editTextAndVerify(SESSION_COOKIE_ADDRESS, DOMAIN);
     }
 
     @Test
-    public void setHTTPOnlyToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, HTTP_ONLY, HTTP_ONLY_ATTR, true);
+    public void setHTTPOnlyToTrue() throws Exception {
+        editCheckboxAndVerify(SESSION_COOKIE_ADDRESS, HTTP_ONLY, true);
     }
 
     @Test
-    public void setHTTPOnlyToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, HTTP_ONLY, HTTP_ONLY_ATTR, false);
+    public void setHTTPOnlyToFalse() throws Exception {
+        editCheckboxAndVerify(SESSION_COOKIE_ADDRESS, HTTP_ONLY, false);
     }
 
     @Test
-    public void editMaxAge() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, MAX_AGE, MAX_AGE_ATTR, NUMERIC_VALID);
+    public void editMaxAge() throws Exception {
+        editTextAndVerify(SESSION_COOKIE_ADDRESS, MAX_AGE, NUMERIC_VALID);
     }
 
     @Test
-    public void editMaxAgeInvalid() throws IOException, InterruptedException, TimeoutException {
+    public void editMaxAgeInvalid() throws Exception {
         verifyIfErrorAppears(MAX_AGE, NUMERIC_INVALID);
     }
 
     @Test
-    public void editName() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, NAME, NAME_ATTR);
+    public void editName() throws Exception {
+        editTextAndVerify(SESSION_COOKIE_ADDRESS, NAME);
     }
 
     @Test
-    public void setSecureToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, SECURE, SECURE_ATTR, true);
+    public void setSecureToTrue() throws Exception {
+        editCheckboxAndVerify(SESSION_COOKIE_ADDRESS, SECURE, true);
     }
 
     @Test
-    public void setSecureToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, SECURE, SECURE_ATTR, false);
+    public void setSecureToFalse() throws Exception {
+        editCheckboxAndVerify(SESSION_COOKIE_ADDRESS, SECURE, false);
     }
 }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/ServletSessionsTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/ServletSessionsTestCase.java
@@ -1,9 +1,9 @@
 package org.jboss.hal.testsuite.test.configuration.undertow;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.hal.testsuite.category.Shared;
-import org.jboss.hal.testsuite.dmr.ResourceAddress;
 import org.jboss.hal.testsuite.page.config.UndertowServletPage;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -11,14 +11,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.operations.Address;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
-/**
- * @author Jan Kasik <jkasik@redhat.com>
- *         Created on 17.9.15.
- */
 @RunWith(Arquillian.class)
 @Category(Shared.class)
 public class ServletSessionsTestCase extends UndertowTestCaseAbstract {
@@ -27,42 +24,39 @@ public class ServletSessionsTestCase extends UndertowTestCaseAbstract {
     private UndertowServletPage page;
 
     //identifiers
-    private final String PATH = "path";
-    private final String RELATIVE_TO = "relative-to";
+    private static final String PATH = "path";
+    private static final String RELATIVE_TO = "relative-to";
 
-    //attribute names
-    private final String PATH_ATTR = "path";
-    private final String RELATIVE_TO_ATTR = "relative-to";
+    private static final String SERVLET_CONTAINER = "servlet-container_" + RandomStringUtils.randomAlphanumeric(5);
+    private static final Address SERVLET_CONTAINER_ADDRESS = UNDERTOW_ADDRESS.and("servlet-container", SERVLET_CONTAINER);
+    private static final Address SERVLET_SESSIONS_ADDRESS = SERVLET_CONTAINER_ADDRESS.and("setting", "persistent-sessions");
 
-
-    private static String servletContainer;
-    private static ResourceAddress address;
 
     @BeforeClass
     public static void setUp() throws InterruptedException, IOException, TimeoutException {
-        servletContainer = operations.createServletContainer();
-        address = servletContainerTemplate.append("/setting=persistent-sessions").resolve(context, servletContainer);
+        operations.add(SERVLET_CONTAINER_ADDRESS);
+        administration.reloadIfRequired();
     }
 
     @Before
     public void before() {
         page.navigate();
-        page.viewServletContainer(servletContainer).switchToSessions();
+        page.viewServletContainer(SERVLET_CONTAINER).switchToSessions();
     }
 
     @AfterClass
     public static void tearDown() throws InterruptedException, IOException, TimeoutException {
-        operations.removeServletContainer(servletContainer);
+        operations.remove(SERVLET_SESSIONS_ADDRESS);
     }
 
     @Test
-    public void editPath() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, PATH, PATH_ATTR);
+    public void editPath() throws Exception {
+        editTextAndVerify(SERVLET_SESSIONS_ADDRESS, PATH);
     }
 
     @Test
-    public void editRelativeTo() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, RELATIVE_TO, RELATIVE_TO_ATTR);
+    public void editRelativeTo() throws Exception {
+        editTextAndVerify(SERVLET_SESSIONS_ADDRESS, RELATIVE_TO, "jboss.server.base.dir");
     }
 
 }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/ServletWebSocketsTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/ServletWebSocketsTestCase.java
@@ -1,9 +1,9 @@
 package org.jboss.hal.testsuite.test.configuration.undertow;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.hal.testsuite.category.Shared;
-import org.jboss.hal.testsuite.dmr.ResourceAddress;
 import org.jboss.hal.testsuite.page.config.UndertowServletPage;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -11,14 +11,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.wildfly.extras.creaper.core.online.operations.Address;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
-/**
- * @author Jan Kasik <jkasik@redhat.com>
- *         Created on 17.9.15.
- */
 @RunWith(Arquillian.class)
 @Category(Shared.class)
 public class ServletWebSocketsTestCase extends UndertowTestCaseAbstract {
@@ -27,52 +24,50 @@ public class ServletWebSocketsTestCase extends UndertowTestCaseAbstract {
     private UndertowServletPage page;
 
     //identifiers
-    private final String BUFFER_POOL = "buffer-pool";
-    private final String DISPATCH_TO_WORKER = "dispatch-to-worker";
-    private final String WORKER = "worker";
+    private static final String BUFFER_POOL = "buffer-pool";
+    private static final String DISPATCH_TO_WORKER = "dispatch-to-worker";
+    private static final String WORKER = "worker";
 
-    //attribute names
-    private final String BUFFER_POOL_ATTR = "buffer-pool";
-    private final String DISPATCH_TO_WORKER_ATTR = "dispatch-to-worker";
-    private final String WORKER_ATTR = "worker";
-
-    private static String servletContainer;
-    private static ResourceAddress address;
+    private static final String SERVLET_CONTAINER = "servlet-container_" + RandomStringUtils.randomAlphanumeric(5);
+    private static final Address SERVLET_CONTAINER_ADDRESS = UNDERTOW_ADDRESS.and("servlet-container", SERVLET_CONTAINER);
+    private static final Address SERVLET_WEBSOCKETS_SETTING = SERVLET_CONTAINER_ADDRESS.and("setting", "websockets");
 
     @BeforeClass
     public static void setUp() throws InterruptedException, IOException, TimeoutException {
-        servletContainer = operations.createServletContainer();
-        address = servletContainerTemplate.append("/setting=websockets").resolve(context, servletContainer);
+        operations.add(SERVLET_CONTAINER_ADDRESS);
+        administration.reloadIfRequired();
     }
 
     @Before
     public void before() {
         page.navigate();
-        page.viewServletContainer(servletContainer).switchToWebSockets();
+        page.viewServletContainer(SERVLET_CONTAINER).switchToWebSockets();
     }
 
     @AfterClass
     public static void tearDown() throws InterruptedException, IOException, TimeoutException {
-        operations.removeServletContainer(servletContainer);
+        operations.remove(SERVLET_CONTAINER_ADDRESS);
+        administration.restartIfRequired();
+        administration.reloadIfRequired();
     }
 
     @Test
-    public void editBufferPool() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, BUFFER_POOL, BUFFER_POOL_ATTR, BUFFER_POOL_VALUE_VALID);
+    public void editBufferPool() throws Exception {
+        editTextAndVerify(SERVLET_WEBSOCKETS_SETTING, BUFFER_POOL, undertowOps.createBufferPool());
     }
 
     @Test
-    public void setDispatchToWorkerToTrue() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, DISPATCH_TO_WORKER, DISPATCH_TO_WORKER_ATTR, true);
+    public void setDispatchToWorkerToTrue() throws Exception {
+        editCheckboxAndVerify(SERVLET_WEBSOCKETS_SETTING, DISPATCH_TO_WORKER, true);
     }
 
     @Test
-    public void setDispatchToWorkerToFalse() throws IOException, InterruptedException, TimeoutException {
-        editCheckboxAndVerify(address, DISPATCH_TO_WORKER, DISPATCH_TO_WORKER_ATTR, false);
+    public void setDispatchToWorkerToFalse() throws Exception {
+        editCheckboxAndVerify(SERVLET_WEBSOCKETS_SETTING, DISPATCH_TO_WORKER, false);
     }
 
     @Test
-    public void editWorker() throws IOException, InterruptedException, TimeoutException {
-        editTextAndVerify(address, WORKER, WORKER_ATTR, WORKER_VALUE_VALID);
+    public void editWorker() throws Exception {
+        editTextAndVerify(SERVLET_WEBSOCKETS_SETTING, WORKER, undertowOps.createWorker());
     }
 }

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowOperations.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowOperations.java
@@ -1,28 +1,13 @@
 package org.jboss.hal.testsuite.test.configuration.undertow;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.mina.util.AvailablePortFinder;
-import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
-import org.jboss.hal.testsuite.dmr.AddressTemplate;
-import org.jboss.hal.testsuite.dmr.DefaultContext;
-import org.jboss.hal.testsuite.dmr.Dispatcher;
-import org.jboss.hal.testsuite.dmr.Operation;
-import org.jboss.hal.testsuite.dmr.ResourceAddress;
-import org.jboss.hal.testsuite.dmr.StatementContext;
 import org.jboss.hal.testsuite.creaper.command.AddSocketBinding;
-import org.jboss.hal.testsuite.util.ConfigUtils;
+import org.jboss.hal.testsuite.creaper.command.RemoveSocketBinding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wildfly.extras.creaper.commands.undertow.AddHttpsSecurityRealm;
-import org.wildfly.extras.creaper.commands.undertow.AddUndertowListener;
 import org.wildfly.extras.creaper.commands.undertow.RemoveHttpsSecurityRealm;
-import org.wildfly.extras.creaper.commands.undertow.RemoveUndertowListener;
-import org.wildfly.extras.creaper.commands.undertow.SslVerifyClient;
-import org.wildfly.extras.creaper.commands.undertow.UndertowListenerType;
 import org.wildfly.extras.creaper.core.CommandFailedException;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
 import org.wildfly.extras.creaper.core.online.operations.Address;
@@ -32,260 +17,135 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
-/**
- * @author Jan Kasik <jkasik@redhat.com>
- *         Created on 17.9.15.
- */
-public final class UndertowOperations {
+public final class UndertowOperations implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(UndertowOperations.class);
 
-    private StatementContext context = new DefaultContext();
-    private AddressTemplate undertowAddressTemplate = AddressTemplate.of("{default.profile}/subsystem=undertow");
-    private AddressTemplate ioWorkerAddressTemplate = AddressTemplate.of("{default.profile}/subsystem=io/worker=*");
-    private AddressTemplate ioBufferPoolAddressTemplate = AddressTemplate.of("{default.profile}/subsystem=io/buffer-pool=*");
-    private AddressTemplate socketBindingAddressTemplate;
-    private AddressTemplate httpServerTemplate = undertowAddressTemplate.append("/server=*");
-    private AddressTemplate servletContainerTemplate = undertowAddressTemplate.append("/servlet-container=*");
-    private AddressTemplate hostTemplate = httpServerTemplate.append("/host=*");
+    private final OnlineManagementClient client;
+    private final Administration administration;
+    private final Operations operations;
+    private final ReferenceHolder referenceHolder = new ReferenceHolder();
 
-    private OnlineManagementClient client;
-    private Administration administration;
-    private Operations operations;
+    private static final Address IO_SUBSYSTEM_ADDRESS = Address.subsystem("io");
+    private static final Address UNDERTOW_SUBSYSTEM_ADDRESS = Address.subsystem("undertow");
 
     public UndertowOperations(OnlineManagementClient client) {
         this.client = client;
         this.operations = new Operations(client);
         this.administration = new Administration(client, 60000);
-        String socketBindingGroup = ConfigUtils.isDomain() ? "full-sockets" : "standard-sockets";
-        this.socketBindingAddressTemplate = AddressTemplate.of("/socket-binding-group=" + socketBindingGroup + "/socket-binding=*");
     }
 
-    public void reloadIfRequiredAndWaitForRunning() throws InterruptedException, TimeoutException, IOException {
-        administration.reloadIfRequired();
+    private Address getWorkerAddress(String name) {
+        return IO_SUBSYSTEM_ADDRESS.and("worker", name);
     }
 
-    public void reloadAndWaitForRunning() throws InterruptedException, TimeoutException, IOException {
-        administration.reload();
+    private Address getBufferPoolAddress(String name) {
+        return IO_SUBSYSTEM_ADDRESS.and("buffer-pool", name);
     }
 
-    public String createAJPListener(String httpServer) throws IOException, CommandFailedException, TimeoutException, InterruptedException {
-        String name = RandomStringUtils.randomAlphanumeric(6);
-        log.info("Creating AJP listener " + name);
-        client.apply(new AddUndertowListener.AjpBuilder(name, httpServer, createSocketBinding()).enabled(true).build());
-        administration.reloadIfRequired();
-        return name;
+    private Address getBufferCacheAddress(String name) {
+        return UNDERTOW_SUBSYSTEM_ADDRESS.and("buffer-cache", name);
     }
 
-    public void removeListener(String httpServer, String listenerName, UndertowListenerType listenerType) throws CommandFailedException, InterruptedException, TimeoutException, IOException {
-        client.apply(new RemoveUndertowListener.Builder(listenerType, listenerName)
-                .forServer(httpServer));
-        administration.reloadIfRequired();
-    }
-
-    public void removeAJPListener(String httpServer, String listenerName) throws CommandFailedException, InterruptedException, IOException, TimeoutException {
-        removeListener(httpServer, listenerName, UndertowListenerType.AJP_LISTENER);
-    }
-
-    public String createHTTPListener(String httpServer) throws IOException, CommandFailedException, TimeoutException, InterruptedException {
-        String name = RandomStringUtils.randomAlphanumeric(6);
-        client.apply(new AddUndertowListener.HttpBuilder(name, httpServer, createSocketBinding()).enabled(true).build());
-        administration.reloadIfRequired();
-        return name;
-    }
-
-    public void removeHTTPListener(String httpServer, String listenerName) throws CommandFailedException, InterruptedException, IOException, TimeoutException {
-        removeListener(httpServer, listenerName, UndertowListenerType.HTTP_LISTENER);
-    }
-
-    public String createHTTPSListener(String httpServer) throws IOException, CommandFailedException, TimeoutException, InterruptedException, OperationException {
-        String name = RandomStringUtils.randomAlphanumeric(6);
-        String realmName = createSecurityRealm();
-        client.apply(new AddUndertowListener.HttpsBuilder(name, httpServer, createSocketBinding())
-                .securityRealm(realmName)
-                .verifyClient(SslVerifyClient.NOT_REQUESTED)
-                .enabled(true)
+    public String createSecurityRealm() throws InterruptedException, CommandFailedException, TimeoutException, IOException {
+        String name = "UndertowSecurityRealm_" + RandomStringUtils.randomAlphanumeric(6);
+        client.apply(new AddHttpsSecurityRealm.Builder(name)
+                .keystorePassword("random")
+                .truststorePassword("random")
+                .keyPassword("random")
+                .keystorePath(getClass().getClassLoader().getResource("clientkeystore").getPath())
                 .build());
-        administration.reloadIfRequired();
-        return name;
-    }
-
-    public void removeHTTPSListener(String httpServer, String listenerName) throws CommandFailedException, InterruptedException, IOException, TimeoutException {
-        removeListener(httpServer, listenerName, UndertowListenerType.HTTPS_LISTENER);
-    }
-
-    /**
-     * @return name of created security realm
-     */
-    public String createSecurityRealm() throws CommandFailedException, IOException,
-            InterruptedException, TimeoutException {
-        String realmName = "SecurityRealm_" + RandomStringUtils.randomAlphanumeric(6);
-        client.apply(new AddHttpsSecurityRealm.Builder(realmName)
-            .keystorePassword("random")
-            .truststorePassword("random")
-            .keyPassword("random")
-            .keystorePath(getClass().getClassLoader().getResource("clientkeystore").getPath())
-            .build());
         administration.reload();
-        return realmName;
-    }
-
-    public void removeSecurityRealm(String realmName) throws CommandFailedException, IOException,
-            InterruptedException, TimeoutException {
-        client.apply(new RemoveHttpsSecurityRealm(realmName));
-        administration.reloadIfRequired();
-    }
-
-    public String createHTTPServerHost(String httpServer) throws InterruptedException, IOException, TimeoutException {
-        String hostName = RandomStringUtils.randomNumeric(6);
-        createHTTPServerHost(httpServer, hostName);
-        return hostName;
-    }
-
-    public String createHTTPServerHost(String httpServer, String hostName) throws InterruptedException, TimeoutException, IOException {
-        ResourceAddress address = hostTemplate.resolve(context, httpServer, hostName);
-        executeAddAction(address);
-        return hostName;
-    }
-
-    public void removeHTTPServerHost(String httpServer, String ajpListener) throws InterruptedException, TimeoutException, IOException {
-        ResourceAddress address = hostTemplate.resolve(context, httpServer, ajpListener);
-        executeRemoveAction(address);
-    }
-
-    public void removeHTTPServerHostIfExists(String httpServer, String ajpListener) throws InterruptedException, TimeoutException, IOException {
-        ResourceAddress address = hostTemplate.resolve(context, httpServer, ajpListener);
-        if (executeReadResourceAction(address)) {
-            executeRemoveAction(address);
-        }
-    }
-
-    public String createHTTPServer() throws InterruptedException, IOException, TimeoutException {
-        String name = "HTTPServer_" + RandomStringUtils.randomAlphanumeric(6);
-        ResourceAddress address = httpServerTemplate.resolve(context, name);
-        executeAddAction(address, true);
-        operations.readResource(Address.of("subsystem", "undertow").and("server", name)); //Workaround for situation when server is listed as unavailable dependency
+        referenceHolder.saveReference(name, ReferenceType.BUFFER_CACHE);
         return name;
-    }
-
-    public void removeHTTPServer(String httpServer) throws InterruptedException, TimeoutException, IOException {
-        executeRemoveAction(httpServerTemplate.resolve(context, httpServer));
-    }
-
-    public String createServletContainer() throws InterruptedException, TimeoutException, IOException {
-        String name = "ServletContainer_" + RandomStringUtils.randomAlphanumeric(6);
-        ResourceAddress address = servletContainerTemplate.resolve(context, name);
-        executeAddAction(address);
-        return name;
-    }
-
-    public void removeServletContainer(String servletContainer) throws InterruptedException, TimeoutException, IOException {
-        executeRemoveAction(servletContainerTemplate.resolve(context, servletContainer));
-    }
-
-    private void executeRemoveAction(ResourceAddress address) throws InterruptedException, IOException, TimeoutException {
-        Dispatcher dispatcher = new Dispatcher();
-        dispatcher.execute(new Operation.Builder("remove", address).build()); //TODO add creaper to all methods, then remove
-        dispatcher.close();
-        reloadIfRequiredAndWaitForRunning();
-    }
-
-    private boolean executeReadResourceAction(ResourceAddress address) {
-        Dispatcher dispatcher = new Dispatcher();
-        boolean result = dispatcher.execute(new Operation.Builder("read-resource", address).build()).isSuccessful();
-        dispatcher.close();
-        return result;
-    }
-
-    private void executeAddAction(ResourceAddress address, Map<String, String> params, boolean reload) throws InterruptedException, IOException, TimeoutException {
-        Operation.Builder operationBuilder = new Operation.Builder("add", address);
-        for (Map.Entry<String, String> entry : params.entrySet()) {
-            operationBuilder.param(entry.getKey(), entry.getValue());
-        }
-        Dispatcher dispatcher = new Dispatcher(); //TODO add creaper to all methods, then remove
-        dispatcher.execute(operationBuilder.build());
-        dispatcher.close();
-        if (reload) reloadIfRequiredAndWaitForRunning();
-    }
-
-    private void executeAddAction(ResourceAddress address, Map<String, String> params) throws InterruptedException, TimeoutException, IOException {
-       executeAddAction(address, params, true);
-    }
-
-    private void executeAddAction(ResourceAddress address) throws InterruptedException, IOException, TimeoutException {
-        executeAddAction(address, Collections.emptyMap());
-    }
-
-    private void executeAddAction(ResourceAddress address, boolean reload) throws InterruptedException, TimeoutException, IOException {
-        executeAddAction(address, Collections.emptyMap(), reload);
     }
 
     public String createWorker() throws InterruptedException, TimeoutException, IOException {
         String name = "UndertowWorker_" + RandomStringUtils.randomAlphanumeric(6);
-        ResourceAddress address = ioWorkerAddressTemplate.resolve(context, name);
-        executeAddAction(address);
+        operations.add(getWorkerAddress(name));
+        referenceHolder.saveReference(name, ReferenceType.WORKER);
         return name;
     }
 
-    public void removeWorker(String name) throws InterruptedException, TimeoutException, IOException {
-        ResourceAddress address = ioWorkerAddressTemplate.resolve(context, name);
-        executeRemoveAction(address);
-    }
-
-    public String createBufferPool() throws InterruptedException, TimeoutException, IOException {
+    public String createBufferPool() throws IOException {
         String name = "UndertowBufferPool_" + RandomStringUtils.randomAlphanumeric(6);
-        ResourceAddress address = ioBufferPoolAddressTemplate.resolve(context, name);
-        executeAddAction(address);
+        operations.add(getBufferPoolAddress(name));
+        referenceHolder.saveReference(name, ReferenceType.BUFFER_POOL);
         return name;
     }
 
-    public void removeBufferPool(String name) throws InterruptedException, TimeoutException, IOException {
-        ResourceAddress address = ioBufferPoolAddressTemplate.resolve(context, name);
-        executeRemoveAction(address);
+    public String createSocketBinding() throws IOException, CommandFailedException {
+        String name = createSocketBindingWithoutReference();
+        referenceHolder.saveReference(name, ReferenceType.SOCKET_BINDING);
+        return name;
     }
 
-    public String createSocketBinding() throws CommandFailedException, IOException {
+    public String createSocketBindingWithoutReference() throws IOException, CommandFailedException {
         String name = "UndertowSocketBinding_" + RandomStringUtils.randomAlphanumeric(6);
-        try (OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient()) {
-            int port = AvailablePortFinder.getNextAvailable();
-            log.info("Obtained port for socket binding '" + name + "' is " + port);
-            client.apply(new AddSocketBinding.Builder(name)
-                    .port(port)
-                    .build());
-        }
+        int port = AvailablePortFinder.getNextAvailable();
+        log.info("Obtained port for socket binding '{}' is '{}'.", name, port);
+        client.apply(new AddSocketBinding.Builder(name)
+                .port(port)
+                .build());
         return name;
     }
 
-    public void removeSocketBinding(String name) throws InterruptedException, TimeoutException, IOException {
-        ResourceAddress address = socketBindingAddressTemplate.resolve(context, name);
-        executeRemoveAction(address);
-    }
-
-    public String addBufferCache() throws IOException {
-        String name = "BufferCache_" + RandomStringUtils.randomAlphanumeric(6);
-        Address address = Address.subsystem("undertow").and("buffer-cache", name);
-        operations.add(address);
+    public String createBufferCache() throws IOException {
+        String name = "UndertowBufferCache_" + RandomStringUtils.randomAlphanumeric(6);
+        operations.add(getBufferCacheAddress(name));
+        referenceHolder.saveReference(name, ReferenceType.BUFFER_CACHE);
         return name;
     }
 
-    public void removeBufferCache(String name) throws IOException, OperationException {
-        Address address = Address.subsystem("undertow").and("buffer-cache", name);
-        operations.removeIfExists(address);
+    @Override
+    public void close() throws IOException, OperationException, CommandFailedException {
+        for (String socketBinding : referenceHolder.getReferencesByType(ReferenceType.SOCKET_BINDING)) {
+            client.apply(new RemoveSocketBinding(socketBinding));
+        }
+        for (String securityRealm : referenceHolder.getReferencesByType(ReferenceType.SECURITY_REALM)) {
+            client.apply(new RemoveHttpsSecurityRealm(securityRealm));
+        }
+        for (String worker : referenceHolder.getReferencesByType(ReferenceType.WORKER)) {
+            operations.remove(getWorkerAddress(worker));
+        }
+        for (String bufferCache : referenceHolder.getReferencesByType(ReferenceType.BUFFER_CACHE)) {
+            operations.remove(getBufferCacheAddress(bufferCache));
+        }
+        for (String bufferPool : referenceHolder.getReferencesByType(ReferenceType.BUFFER_POOL)) {
+            operations.remove(getBufferPoolAddress(bufferPool));
+        }
     }
 
-    public void writeAttribute(ResourceAddress resourceAddress, String attrName, boolean attrValue) {
-        Operation writeAttrOperation = new Operation.Builder(WRITE_ATTRIBUTE_OPERATION, resourceAddress)
-                .param(NAME, attrName)
-                .param(VALUE, attrValue)
-                .build();
-        Dispatcher dispatcher = new Dispatcher();
-        try {
-            dispatcher.execute(writeAttrOperation);
-        } finally {
-            dispatcher.close();
+    private final class ReferenceHolder {
+
+        private final Map<ReferenceType, List<String>> references;
+
+        public ReferenceHolder() {
+            this.references = new HashMap<>();
         }
+
+        public void saveReference(String reference, ReferenceType type) {
+            if (!references.containsKey(type)) {
+                references.put(type, new LinkedList<>());
+            }
+            references.get(type).add(reference);
+        }
+
+        public List<String> getReferencesByType(ReferenceType type) {
+            if (!references.containsKey(type)) {
+                return Collections.emptyList();
+            }
+            return references.get(type);
+        }
+    }
+
+    private enum ReferenceType {
+        SOCKET_BINDING, BUFFER_CACHE, BUFFER_POOL, WORKER, SECURITY_REALM
     }
 }

--- a/common/src/main/java/org/jboss/hal/testsuite/page/config/UndertowServletPage.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/page/config/UndertowServletPage.java
@@ -28,6 +28,7 @@ public class UndertowServletPage extends UndertowPage implements Navigatable {
                 .step("Settings", "Servlet/JSP")
                 .selectRow().invoke(FinderNames.VIEW);
         Application.waitUntilVisible();
+        Console.withBrowser(browser).dismissReloadRequiredWindowIfPresent();
     }
 
     public UndertowServletPage selectServletContainer(String containerName) {


### PR DESCRIPTION
- There was still some errors in server log which caused undertow service to fail at server startup. I tried to find attributes which setting to wrong value were causing this behavior and set them to right value.
- Added Creaper to tests
- Better resource handling - UndertowOperations#close
- Removed unnecessary duplicate constants in test cases
