### PR TITLE
Fixed port range error in AvailablePortFinder

### DIFF
--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/connector/MailTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/connector/MailTestCase.java
@@ -242,7 +242,7 @@ public class MailTestCase {
 
     private static String createSocketBinding(String name) throws IOException, CommandFailedException {
         try (OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient()) {
-            int port = AvailablePortFinder.getNextAvailableUserPort();
+            int port = AvailablePortFinder.getNextAvailableNonPrivilegedPort();
             log.info("Obtained port for socket binding '" + name + "' is " + port);
             client.apply(new AddSocketBinding.Builder(name)
                     .port(port)

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupsOperations.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupsOperations.java
@@ -51,7 +51,7 @@ class JGroupsOperations {
     public String createSocketBinding(String name) throws IOException, CommandFailedException {
         //editing on full-ha profile in domain
         String socketBindingGroup = client.options().isDomain ? "full-ha-sockets" : "standard-sockets";
-        int port = AvailablePortFinder.getNextAvailableUserPort();
+        int port = AvailablePortFinder.getNextAvailableNonPrivilegedPort();
         logger.info("Obtained port for socket binding '" + name + "' is " + port);
         client.apply(new AddSocketBinding.Builder(name, socketBindingGroup)
                 .port(port)

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/AbstractMessagingTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/messaging/AbstractMessagingTestCase.java
@@ -151,7 +151,7 @@ public abstract class AbstractMessagingTestCase {
 
     protected static String createSocketBinding(String name) throws CommandFailedException {
         client.apply(new AddSocketBinding.Builder(name)
-                .port(AvailablePortFinder.getNextAvailableUserPort())
+                .port(AvailablePortFinder.getNextAvailableNonPrivilegedPort())
                 .build());
         addSocketBindingToList(name);
         return name;

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/transactions/TransactionsOperations.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/transactions/TransactionsOperations.java
@@ -22,7 +22,7 @@ public class TransactionsOperations {
 
     public String createSocketBinding() throws CommandFailedException, IOException {
         String name = "TransactionsOpsSB_" + RandomStringUtils.randomAlphanumeric(6);
-        int port = AvailablePortFinder.getNextAvailableUserPort();
+        int port = AvailablePortFinder.getNextAvailableNonPrivilegedPort();
         log.info("Obtained port for socket binding '" + name + "' is " + port);
         client.apply(new AddSocketBinding.Builder(name)
                 .port(port)

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowOperations.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/UndertowOperations.java
@@ -88,7 +88,7 @@ public final class UndertowOperations implements AutoCloseable {
 
     public String createSocketBindingWithoutReference() throws IOException, CommandFailedException {
         String name = "UndertowSocketBinding_" + RandomStringUtils.randomAlphanumeric(6);
-        int port = AvailablePortFinder.getNextAvailableUserPort();
+        int port = AvailablePortFinder.getNextAvailableNonPrivilegedPort();
         log.info("Obtained port for socket binding '{}' is '{}'.", name, port);
         client.apply(new AddSocketBinding.Builder(name)
                 .port(port)

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/web/ModClusterTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/web/ModClusterTestCase.java
@@ -96,8 +96,8 @@ public class ModClusterTestCase {
     @BeforeClass
     public static void beforeClass() throws IOException, CommandFailedException {
         try (OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient()) {
-            int port = AvailablePortFinder.getNextAvailableUserPort();
-            int multicastPort = AvailablePortFinder.getNextAvailableUserPort();
+            int port = AvailablePortFinder.getNextAvailableNonPrivilegedPort();
+            int multicastPort = AvailablePortFinder.getNextAvailableNonPrivilegedPort();
             log.info("Obtained port for socket binding '" + ADVERTISE_SOCKET_VALUE + "' is " + port +
                     ", multicast port is " + multicastPort);
             client.apply(new AddSocketBinding.Builder(ADVERTISE_SOCKET_VALUE)

--- a/common/src/main/java/org/jboss/hal/testsuite/util/AvailablePortFinder.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/util/AvailablePortFinder.java
@@ -22,7 +22,7 @@ public class AvailablePortFinder {
     /**
      * The maximum number of user port number.
      */
-    public static final int MAX_PORT_NUMBER = 49151;
+    public static final int MAX_PORT_NUMBER = 65535;
 
     /**
      * Prevents creating a new instance.
@@ -151,7 +151,7 @@ public class AvailablePortFinder {
     /**
      * Gets a port which is not used in both TCP and UDP.
      */
-    public static int getNextAvailableUserPort() {
+    public static int getNextAvailableNonPrivilegedPort() {
         int port = getNextAvailableTCPPort();
         if (isUDPPortFreeToUse(port)) {
             return port;


### PR DESCRIPTION
Due to the fact, that the `new ServerSocket(0)` allocates port in ephemeral range, I had to set higher `MAX_PORT_NUMBER` and refactor `getNextAvailableUserPort()` method. 
