### PR TITLE
Ensure reload will be finished before WebAccessTestCase end.

### DIFF
--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/general/WebAccessTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/general/WebAccessTestCase.java
@@ -1,22 +1,26 @@
 package org.jboss.hal.testsuite.test.configuration.general;
 
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.hal.testsuite.category.Shared;
-import org.jboss.hal.testsuite.cli.CliClient;
-import org.jboss.hal.testsuite.cli.CliClientFactory;
-import org.jboss.hal.testsuite.cli.CliConstants;
-import org.jboss.hal.testsuite.cli.DomainCliClient;
+import org.jboss.hal.testsuite.creaper.ManagementClientProvider;
 import org.jboss.hal.testsuite.page.home.HomePage;
 import org.jboss.hal.testsuite.util.Console;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.Address;
+import org.wildfly.extras.creaper.core.online.operations.Operations;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 
 /**
  * @author mkrajcov <mkrajcov@redhat.com>
@@ -25,18 +29,25 @@ import org.openqa.selenium.WebDriver;
 @Category(Shared.class)
 public class WebAccessTestCase {
 
-    private static CliClient client = CliClientFactory.getClient();
+    private static final OnlineManagementClient client = ManagementClientProvider.createOnlineManagementClient();
+    private static final Operations ops = new Operations(client);
+    private static final Administration adminOps = new Administration(client);
+
     @Drone
     public WebDriver browser;
 
     @AfterClass
-    public static void afterClass() {
-        toggleWebConsole(true);
+    public static void afterClass() throws IOException, InterruptedException, TimeoutException {
+        try {
+            toggleWebConsole(true);
+        } finally {
+            IOUtils.closeQuietly(client);
+        }
     }
 
-    @Test(expected = TimeoutException.class)
+    @Test(expected = org.openqa.selenium.TimeoutException.class)
     @InSequence(0)
-    public void disabledAccess() {
+    public void disabledAccess() throws IOException, InterruptedException, TimeoutException {
         toggleWebConsole(false);
         Graphene.goTo(HomePage.class);
         browser.navigate().refresh();
@@ -45,19 +56,16 @@ public class WebAccessTestCase {
 
     @Test
     @InSequence(1)
-    public void enabledAccess() {
+    public void enabledAccess() throws IOException, InterruptedException, TimeoutException {
         toggleWebConsole(true);
         Graphene.goTo(HomePage.class);
         browser.navigate().refresh();
         Console.withBrowser(browser).waitUntilLoaded();
     }
 
-    private static void toggleWebConsole(boolean enabled) {
-        if (client instanceof DomainCliClient) {
-            client.writeAttribute(CliConstants.DOMAIN_HTTP_INTERFACE_ADDRESS, "console-enabled", Boolean.toString(enabled));
-        } else {
-            client.writeAttribute(CliConstants.STANDALONE_HTTP_INTERFACE_ADDRESS, "console-enabled", Boolean.toString(enabled));
-        }
-        client.reload();
+    private static void toggleWebConsole(boolean enabled) throws IOException, InterruptedException, TimeoutException {
+        ops.writeAttribute(Address.coreService("management").and("management-interface", "http-interface"),
+                "console-enabled", enabled);
+        adminOps.reloadIfRequired();
     }
 }


### PR DESCRIPTION
Avoid WebAccessTestCase breaking following tests due to ongoing reload.