### PR TITLE
Fixed invalid socket binding test in JGroup*TestCase

### DIFF
--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
@@ -132,7 +132,7 @@ public class JGroupAbstractTestCase {
 
     @Test
     public void socketBindingEditInvalid() throws Exception {
-        verifyValueIsNotSaved(TRANSPORT_ADDRESS, "SocketBinding", "socket-binding", RandomStringUtils.randomAlphabetic(6));
+        verifyValueIsNotSaved(TRANSPORT_ADDRESS, "socketBinding", "socket-binding", RandomStringUtils.randomAlphabetic(6));
     }
 
     @Test


### PR DESCRIPTION
Other failing tests in JGroups are fixed by #231 