### PR TITLE
Fixed BufferPoolTestCase

### DIFF
--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/io/BufferPoolTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/io/BufferPoolTestCase.java
@@ -144,7 +144,7 @@ public class BufferPoolTestCase {
     public void toggleDirectBuffers() throws Exception {
         final ModelNodeResult originalNodeResult = operations.readAttribute(BUFFER_POOL_ADDRESS, DIRECT_BUFFERS);
         originalNodeResult.assertSuccess();
-        final boolean originalValue = !originalNodeResult.hasDefinedValue() || originalNodeResult.booleanValue();
+        final boolean originalValue = originalNodeResult.hasDefinedValue() && originalNodeResult.booleanValue();
         try {
             new ConfigChecker.Builder(client, BUFFER_POOL_ADDRESS)
                     .configFragment(page.getConfigFragment())


### PR DESCRIPTION
Default value was undefined which equals unchecked checkbox, no change was made and instead of result, exception was thrown