### PR TITLE
EAP7-583: Webconsole show content of archive even if deployment is not exploded

### DIFF
--- a/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/deployments/ManagedDeploymentsTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/runtime/deployments/ManagedDeploymentsTestCase.java
@@ -329,12 +329,13 @@ public class ManagedDeploymentsTestCase {
     }
 
     @Test
-    public void medBrowseContentOnUnexplodedEnabledDeploymentExpectFailure() throws Exception {
+    public void medBrowseContentOnUnexplodedEnabledDeploymentExpectSuccess() throws Exception {
         Row row = navigation.step(FinderNames.DEPLOYMENT, DEPLOYMENT_MANAGED_ENABLED_2).selectRow();
         Console.withBrowser(browser).dismissReloadRequiredWindowIfPresent();
 
         row.invoke(FinderNames.BROWSE_CONTENT);
-        assertEquals("Cannot read content from an unexploded deployment", page.getAlertArea().getMessage());
+        List<String> itemsInDeploment = page.getDeploymentBrowsedContentItems();
+        ops.verifyDeploymentContentDefault(itemsInDeploment);
     }
 
     @Test


### PR DESCRIPTION
Instead of failing if the read-content operation is invoked for archived content or with a path parameter indicating a path inside archived child content, instead extract the content from the archive and return it.