### PR TITLE
[HAL-1356] It is not possible to disable SSO on application security domain in Undertow subsystem in Web Console

### DIFF
--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/applicationsecuritydomain/ApplicationSecurityDomainSingleSignOnTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/undertow/applicationsecuritydomain/ApplicationSecurityDomainSingleSignOnTestCase.java
@@ -145,6 +145,28 @@ public class ApplicationSecurityDomainSingleSignOnTestCase {
     }
 
     /**
+     * @tpTestDetails Try to disable Single Sign On for selected security domain with already enabled SSO by clicking on
+     * button present in Web Console configuration.
+     * Validate that SSO was disabled in model.
+     */
+    @Test
+    public void testDisableSSO() throws Exception {
+        try {
+            page.getResourceManager().selectByName(APP_SEC_DOMAIN_WITH_SSO_TBR_ADDRESS.getLastPairValue());
+            page.switchToSSOConfigTab();
+            page.disableSSO()
+                    .confirmAndDismissReloadRequiredMessage()
+                    .assertClosed();
+
+            new ResourceVerifier(APP_SEC_DOMAIN_WITH_SSO_TBR_ADDRESS.and(SETTING, SINGLE_SIGN_ON), client)
+                    .verifyDoesNotExist();
+        } finally {
+            operations.removeIfExists(APP_SEC_DOMAIN_WITH_SSO_TBR_ADDRESS.and(SETTING, SINGLE_SIGN_ON));
+            administration.reloadIfRequired();
+        }
+    }
+
+    /**
      * @tpTestDetails Try to edit credential reference of aalready created security domain in Web Console's Undertow
      * subsystem configuration.
      * Validate edited attribute values in the model.
@@ -152,7 +174,6 @@ public class ApplicationSecurityDomainSingleSignOnTestCase {
      * <li>store + alias</li>
      * <li>clear text</li>
      * <li>illegal combination of both</li></ul>
-
      */
     @Test
     public void testCredentialReferenceSetting() throws Exception {

--- a/common/src/main/java/org/jboss/hal/testsuite/page/config/ApplicationSecurityDomainPage.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/page/config/ApplicationSecurityDomainPage.java
@@ -8,6 +8,7 @@ import org.jboss.hal.testsuite.fragment.ConfigAreaFragment;
 import org.jboss.hal.testsuite.fragment.ConfigFragment;
 import org.jboss.hal.testsuite.fragment.config.undertow.AddApplicationSecurityDomainWizard;
 import org.jboss.hal.testsuite.fragment.config.undertow.AddSSOWizard;
+import org.jboss.hal.testsuite.fragment.shared.modal.ConfirmationWindow;
 import org.jboss.hal.testsuite.util.Console;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -41,6 +42,11 @@ public class ApplicationSecurityDomainPage extends ConfigurationPage {
     public AddSSOWizard enableSSO() {
         clickButton("Enable Single Sign On");
         return Console.withBrowser(browser).openedWizard(AddSSOWizard.class);
+    }
+
+    public ConfirmationWindow disableSSO() {
+        clickButton("Disable Single Sign On");
+        return Console.withBrowser(browser).openedWindow(ConfirmationWindow.class);
     }
 
     public ConfigFragment switchToSSOConfigTab() {


### PR DESCRIPTION
Added test for https://issues.jboss.org/browse/HAL-1356