### PR TITLE
Exclude instead of include JUnit test categories

### DIFF
--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/EETestCaseAbstract.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/ee/EETestCaseAbstract.java
@@ -26,7 +26,7 @@ import java.io.IOException;
  * @author Jan Kasik
  *         Created on 8.9.15.
  */
-public class EETestCaseAbstract {
+public abstract class EETestCaseAbstract {
 
     @Drone
     protected WebDriver browser;

--- a/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
+++ b/basic/src/test/java/org/jboss/hal/testsuite/test/configuration/jgroups/JGroupAbstractTestCase.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class JGroupAbstractTestCase {
+public abstract class JGroupAbstractTestCase {
 
     protected static Address BASE_ADDRESS;
     protected static Address PROTOCOL_ADDRESS;

--- a/common/src/main/java/org/jboss/hal/testsuite/category/Shared.java
+++ b/common/src/main/java/org/jboss/hal/testsuite/category/Shared.java
@@ -24,9 +24,12 @@ package org.jboss.hal.testsuite.category;
 
 /**
  * <p>Intended to be used only as a JUnit Category designation parameter
- * in&nbsp;{@link org.junit.experimental.categories.Category} annotation</p>
+ * in&nbsp;{@link org.junit.experimental.categories.Category} annotation.
+ * It is not necessary to be used any more.
+ * Tests without @Standalone or @Domain annotation will be run in both modes.</p>
  * Created by pjelinek on Mar 31, 2015
  */
+@Deprecated
 public interface Shared {
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -307,10 +307,9 @@
         <arquillian.launch>server</arquillian.launch>
         <suite.mode>standalone</suite.mode>
         <suite.server>wildfly</suite.server>
-        <test.category>
-          org.jboss.hal.testsuite.category.Shared,
-          org.jboss.hal.testsuite.category.Standalone
-        </test.category>
+        <test.excluded.category>
+          org.jboss.hal.testsuite.category.Domain
+        </test.excluded.category>
       </properties>
       <dependencies>
         <dependency>
@@ -328,10 +327,9 @@
         <suite.mode>domain</suite.mode>
         <suite.server>wildfly</suite.server>
         <arq.managementPort>9999</arq.managementPort>
-        <test.category>
-          org.jboss.hal.testsuite.category.Shared,
-          org.jboss.hal.testsuite.category.Domain
-        </test.category>
+        <test.excluded.category>
+          org.jboss.hal.testsuite.category.Standalone
+        </test.excluded.category>
       </properties>
       <dependencies>
         <dependency>
@@ -385,7 +383,7 @@
             <arq.managementPort>${arq.managementPort}</arq.managementPort>
           </systemPropertyVariables>
           <argLine>${argLine}</argLine>
-          <groups>${test.category}</groups>
+          <excludedGroups>${test.excluded.category}</excludedGroups>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Instead of explicitly including tests with specified categories to standalone/domain profile runs
tests with particular categories will be excluded from runs from now.
Motivation is to avoid not runnnig tests with forgotten category annotation.
As a consequence shared test category is useless and deprecated from now.